### PR TITLE
Fix handling of 'seen prs' when regenerating changelog.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,11 @@ History
 
 
 ------------------
+0.1.5 (14-09-2023)
+------------------
+* Bootstrap history fixes for regenerating existing docs
+
+------------------
 0.1.4 (30-06-2023)
 ------------------
 * Skip empty prerelease changelog when parsing changelog

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -375,7 +375,7 @@ def create_changelog(release_version: Version, galaxy_root: Path):
     seen_prs = set()
     try:
         with open(prs_file) as fh:
-            seen_prs = set(map(int, re.findall(r"\.\. _Pull Request (\d*): https", fh.read())))
+            seen_prs = set(map(int, re.findall(r"\.\. _Pull Request (\d+): https", fh.read())))
     except FileNotFoundError:
         pass
     _write_file(prs_file, PRS_TEMPLATE, skip_if_exists=True)

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -375,7 +375,7 @@ def create_changelog(release_version: Version, galaxy_root: Path):
     seen_prs = set()
     try:
         with open(prs_file) as fh:
-            seen_prs = set(re.findall(r"\.\. _Pull Request (\d*): https", fh.read()))
+            seen_prs = set(map(int, re.findall(r"\.\. _Pull Request (\d*): https", fh.read())))
     except FileNotFoundError:
         pass
     _write_file(prs_file, PRS_TEMPLATE, skip_if_exists=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-release-util
 url = https://github.com/galaxyproject/galaxy-release-util
-version = 0.1.4
+version = 0.1.5
 
 [options]
 include_package_data = True


### PR DESCRIPTION
Included version bump, will create PR to galaxy to update once we publish this.