### PR TITLE
Ignore empty lines, comments when reading in packages_by_dep_dag.txt file

### DIFF
--- a/galaxy_release_util/point_release.py
+++ b/galaxy_release_util/point_release.py
@@ -117,8 +117,8 @@ class Package:
 def get_sorted_package_paths(galaxy_root: pathlib.Path) -> List[pathlib.Path]:
     root_package_path = galaxy_root.joinpath("packages")
     sorted_packages = root_package_path.joinpath("packages_by_dep_dag.txt").read_text().splitlines()
-    # Check that all packages are listed in packages_by_dep_dag.txt ?
-    return [root_package_path.joinpath(package) for package in sorted_packages]
+    # Ignore empty lines and lines beginning with "#"
+    return [root_package_path.joinpath(p) for p in sorted_packages if p and not p.startswith("#")]
 
 
 def read_package(package_path: pathlib.Path) -> Package:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-pythonpath = .

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import pytest
 
 from galaxy_release_util.point_release import (
@@ -20,32 +22,16 @@ baz
 """
 
 
-@pytest.fixture(scope="session")
-def make_version_file():
-    def f(root):
-        file = root / "lib" / "galaxy" / "version.py"
-        file.parent.mkdir(parents=True)
-        file.write_text(VERSION_PY_CONTENTS)
-
-    return f
+def write_contents(path: pathlib.Path, contents: str):
+    path.parent.mkdir(parents=True)
+    path.write_text(contents)
 
 
-@pytest.fixture(scope="session")
-def make_packages_file():
-    def f(root):
-        file = root / "packages" / "packages_by_dep_dag.txt"
-        file.parent.mkdir(parents=True)
-        file.write_text(PACKAGES_BY_DEP_DAG_CONTENTS)
-
-    return f
-
-
-@pytest.fixture(scope="session")
-def galaxy_root(tmp_path_factory, make_version_file, make_packages_file):
-    tmp_root = tmp_path_factory.mktemp("galaxy_root")
-    make_version_file(tmp_root)
-    make_packages_file(tmp_root)
-    return tmp_root
+@pytest.fixture()
+def galaxy_root(tmp_path: pathlib.Path):
+    write_contents(tmp_path / "lib" / "galaxy" / "version.py", VERSION_PY_CONTENTS)
+    write_contents(tmp_path / "packages" / "packages_by_dep_dag.txt", PACKAGES_BY_DEP_DAG_CONTENTS)
+    return tmp_path
 
 
 def test_get_root_version(galaxy_root):

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,10 +1,9 @@
-import pathlib
-
 import pytest
 
 from galaxy_release_util.point_release import (
     get_next_devN_version,
     get_root_version,
+    get_sorted_package_paths,
 )
 
 VERSION_PY_CONTENTS = """VERSION_MAJOR = "23.0"
@@ -12,13 +11,41 @@ VERSION_MINOR = "2"
 VERSION = VERSION_MAJOR + (f".{VERSION_MINOR}" if VERSION_MINOR else "")
 """
 
+PACKAGES_BY_DEP_DAG_CONTENTS = """
+foo
 
-@pytest.fixture()
-def galaxy_root(tmp_path: pathlib.Path):
-    version_py = tmp_path / "lib" / "galaxy" / "version.py"
-    version_py.parent.mkdir(parents=True)
-    version_py.write_text(VERSION_PY_CONTENTS)
-    return tmp_path
+bar
+#this is a comment
+baz
+"""
+
+
+@pytest.fixture(scope="session")
+def make_version_file():
+    def f(root):
+        file = root / "lib" / "galaxy" / "version.py"
+        file.parent.mkdir(parents=True)
+        file.write_text(VERSION_PY_CONTENTS)
+
+    return f
+
+
+@pytest.fixture(scope="session")
+def make_packages_file():
+    def f(root):
+        file = root / "packages" / "packages_by_dep_dag.txt"
+        file.parent.mkdir(parents=True)
+        file.write_text(PACKAGES_BY_DEP_DAG_CONTENTS)
+
+    return f
+
+
+@pytest.fixture(scope="session")
+def galaxy_root(tmp_path_factory, make_version_file, make_packages_file):
+    tmp_root = tmp_path_factory.mktemp("galaxy_root")
+    make_version_file(tmp_root)
+    make_packages_file(tmp_root)
+    return tmp_root
 
 
 def test_get_root_version(galaxy_root):
@@ -35,3 +62,11 @@ def test_get_next_devN_version(galaxy_root):
     assert version.minor == 0
     assert version.micro == 3
     assert version.dev == 0
+
+
+def test_get_sorted_package_paths(galaxy_root):
+    packages = get_sorted_package_paths(galaxy_root)
+    assert len(packages) == 3
+    assert packages[0].name == "foo"
+    assert packages[1].name == "bar"
+    assert packages[2].name == "baz"


### PR DESCRIPTION
Also, add test; use session-scoped fixtures not to regenerate the same files for each test.