### PR TITLE
Fix release script if multiple bug fixes subheadings in changelog

### DIFF
--- a/galaxy_release_util/point_release.py
+++ b/galaxy_release_util/point_release.py
@@ -200,7 +200,12 @@ def parse_changelog(package: Package) -> List[ChangelogItem]:
                     section_delimiter = "=" * len(kind)
                     changes.append(f"\n{section_delimiter}\n{kind}\n{section_delimiter}\n")
                     for section_changelog_item in changelog_item[1:]:
-                        assert isinstance(section_changelog_item, docutils.nodes.bullet_list)
+                        if isinstance(section_changelog_item, docutils.nodes.system_message):
+                            # Likely a warning that subsection (e.g. Bug fixes) is not unique
+                            continue
+                        assert isinstance(section_changelog_item, docutils.nodes.bullet_list), type(
+                            section_changelog_item
+                        )
                         for child in section_changelog_item:
                             add_changelog_item(changes, child)
             changelog_items.append(ChangelogItem(version=current_version, date=current_date, changes=changes))


### PR DESCRIPTION
Fixes
```
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/.venv/bin/galaxy-release-util", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.11/site-packages/galaxy_release_util/point_release.py", line 638, in create_point_release
    package = read_package(package_path)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.11/site-packages/galaxy_release_util/point_release.py", line 159, in read_package
    package.package_history = parse_changelog(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.11/site-packages/galaxy_release_util/point_release.py", line 203, in parse_changelog
    assert isinstance(section_changelog_item, docutils.nodes.bullet_list)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```