### PR TITLE
Fix strip_release bug

### DIFF
--- a/galaxy_release_util/metadata.py
+++ b/galaxy_release_util/metadata.py
@@ -98,4 +98,4 @@ def _pr_to_labels(pr: PullRequest) -> List[str]:
 
 
 def strip_release(message):
-    return re.sub(r"^\s*\[.*\]\s*", r"", message)
+    return re.sub(r"^\s*\[[\w,\.,-]*\]\s*", r"", message)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,15 @@
+from galaxy_release_util.metadata import strip_release
+
+
+def test_strip_release():
+    """Verify that the first occurance of [*] is stripped out."""
+    assert strip_release("foo") == "foo"
+    assert strip_release("[1]foo") == "foo"
+    assert strip_release("[1.2.3]foo") == "foo"
+    assert strip_release("[]foo") == "foo"
+    assert strip_release("[][]foo") == "[]foo"
+    assert strip_release("foo[]") == "foo[]"
+    assert strip_release("[]foo[]") == "foo[]"
+    assert strip_release("foo[bar]") == "foo[bar]"
+    assert strip_release("foo[]baz") == "foo[]baz"
+    assert strip_release("foo[bar]baz") == "foo[bar]baz"


### PR DESCRIPTION
If there were more than one sets of brackets, the value was replaced by an empty string