### PR TITLE
Don't add ``requirements.txt`` to ``meta_package.modified_paths``

### DIFF
--- a/galaxy_release_util/point_release.py
+++ b/galaxy_release_util/point_release.py
@@ -775,7 +775,8 @@ def build_meta_dependencies(meta_package: Package, packages: List[Package], new_
     meta_deps.sort()
     requirements_txt = meta_package.path.joinpath("requirements.txt")
     requirements_txt.write_text("\n".join(meta_deps))
-    meta_package.modified_paths.append(requirements_txt)
+    # Don't add requirements.txt to meta_package.modified_paths, since this is
+    # in Galaxy's .gitignore
 
 
 def show_modified_paths_and_diff(galaxy_root: Path, modified_paths: List[Path], no_confirm: bool) -> None:


### PR DESCRIPTION
since this is in Galaxy's ``.gitignore`` .

xref: https://github.com/galaxyproject/galaxy/commit/7a8399ca858c85e04f6ae6d280595d56e12ae2d9

Requirements were re-added by mistake into the file in https://github.com/galaxyproject/galaxy/commit/2533594f58e0bbd2d4d9ceb4f7882b371bfdc692