### PR TITLE
Restructure release notes to account for GitHub notes

### DIFF
--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -157,7 +157,7 @@ Builtin Tool Updates
 .. tools
 
 Please see the full `release notes <https://github.com/galaxyproject/galaxy/releases/tag/v${release}.0>`__ for more details.
-The admin-facing release notes are available :doc:`${release} here <${release}_announce>`.
+The admin-facing release notes are available :doc:`here <${release}_announce>`.
 
 .. include:: ${release}_prs.rst
 


### PR DESCRIPTION
Since we're considering using the release drafter to have detailed release notes on the galaxy GitHub repo, we do not need the entire list of bug fixes and enhancements. This takes care of that.

Also restructures the user facing and admin notes to account for that.

### User Facing Release Notes:

**Note:** The link to the full release notes at the top will now be a link to the GitHub release notes. I've made sure that at the bottom we again provide that link in addition to the admin facing notes.

| Before | After |
| ---- | ---- |
| <img width="391" height="911" alt="oxo6fU38pE" src="https://github.com/user-attachments/assets/dab9b7c4-e986-4b5e-b617-56d22298abd3" /> | <img width="391" height="911" alt="firefox_6WekmZO8yZ" src="https://github.com/user-attachments/assets/85df6bd1-85c8-481e-9d55-fe2378e8fb0b" /> |

### Admin Release Notes:

Sorry for the difference in img sizes 😬 

**Note:** The biggest difference is that no more **Highlights** and **Release Notes** sections in here.

| Before | After |
| ---- | ---- |
| <img width="236" height="783" alt="image" src="https://github.com/user-attachments/assets/5888fd7e-ed18-46f6-9bb6-94df2acdaa6c" /> | <img width="391" height="911" alt="pLP3ajp6Xs" src="https://github.com/user-attachments/assets/e816dfc6-6314-4192-b09b-1a710384266e" /> |


