### PR TITLE
Add Release Manager Task Instructions

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -14,11 +14,9 @@ Two weeks before the actual freeze, we announce the freeze meeting for the upcom
 
 1. Send the following message:
 
-```
-🗓️ Freeze Meeting on <DATE_OF_FREEZE_MEETING>
-
-Hello everyone, we will meet on <DATE_OF_FREEZE_MEETING> for the Freeze Meeting, one week before the actual freeze. We will review open PRs, decide what will be included in the <RELEASE_TAG> release, and assign reviewers to ensure merges are completed by the freeze date. If you have outstanding PRs, please make sure they are set to ready-for-review before the meeting.
-```
+>🗓️ Freeze Meeting on <DATE_OF_FREEZE_MEETING>
+>
+>We will meet on <DATE_OF_FREEZE_MEETING> for the Freeze Meeting, one week before the actual freeze. We will review open PRs, decide what will be included in the <RELEASE_TAG> release, and assign reviewers to ensure merges are completed by the freeze date. If you have outstanding PRs, please make sure they are set to ready-for-review before the meeting.
 
 2. To these channels:
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -4,9 +4,9 @@ This document provides a step-by-step guide for managing Galaxy releases. It out
 
 ## Tasks
 
-### Step 1: Determine Freeze Date
+### Step 1: Determine Freeze and Release Date
 
-Discuss and agree on an appropriate freeze date (DATE_OF_FREEZE_MEETING) with the team during a dev meeting.
+Discuss and agree on an appropriate freeze date (DATE_OF_FREEZE) and anticipated release date (RELEASE_DATE) with the team during a dev meeting.
 
 ### Step 2: Announce Freeze Meeting
 
@@ -64,3 +64,29 @@ Use the `which` command to confirm that the version of `galaxy-release-util` bei
 ```bash
 which galaxy-release-util
 ```
+
+### Step 5: Close Previous Release Publication Issues
+We ensure that all previous release publication issues are closed before publishing a new one.
+
+1. Go to: [https://github.com/galaxyproject/galaxy/issues](https://github.com/galaxyproject/galaxy/issues)
+   
+2. Search for: `Publication of Galaxy Release`
+ 
+3. Select and close previous publication issues
+
+### Step 6: Open Release Publication Issue
+Using `galaxy-release-util`, we are now ready to publish the release issue on `GitHub`, which will publicly track the release publication stages using a checklist of items.
+
+1. Make sure that you are in your `galaxy-release-util` virtual environment.
+
+2. Enter your Galaxy root directory:
+```bash
+cd <GALAXY_ROOT>
+```
+
+3. Review the release issue output in the terminal (`--dry-run`):
+```bash
+galaxy-release-util create-release-issue <RELEASE_TAG> --freeze-date 'YEAR-MONTH-DAY' --next-version <NEXT_RELEASE_TAG> --dry-run y --release-date 'YEAR-MONTH-DAY'
+```
+
+4. Re-run the above command without the `--dry-run` argument to actually open a release publication issue on `GitHub`.

--- a/TASKS.md
+++ b/TASKS.md
@@ -95,3 +95,25 @@ Use the following filter to identify PRs without `kind/*` labels and assign the 
 1. Go to: [https://github.com/galaxyproject/galaxy/pulls](https://github.com/galaxyproject/galaxy/pulls)  
 2. Search for: `is:open is:pr milestone:<RELEASE_TAG> -label:"kind/feature" -label:"kind/bug" -label:"kind/enhancement" -label:"kind/refactoring" -label:dependencies`
 3. Assign proper labels, and milestones to these PRs
+
+### Step 8: Review of Blockers
+
+Write the following message to above channels:
+
+> 📌 We're Frozen!
+> Hey everyone!
+> As planned, as of today we're officially frozen for <RELEASE_TAG> - no new features or enhancements against the <RELEASE_TAG> milestone after this point.
+> We still have <NUMBER_OF_OPEN_PRS> PRs from the freeze list that need to be merged before we can branch. It would be great if folks can review these remaining ones as soon as possible, so we can actually branch. Even if a PR is assigned to someone else, feel free to jump in with a review!
+> Link to the remaining PRs: https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+-label%3A%22kind%2Fbug%22+-is%3Adraft+milestone%3A<RELEASE_TAG>
+
+### Step 9: Review Merged PRs
+
+1. Go to: [https://github.com/galaxyproject/galaxy/pulls](https://github.com/galaxyproject/galaxy/pulls)
+
+2. Identify all PRs merged since the last release that are missing the appropriate tag and assign the correct tag.
+
+Search for: `is:pr is:merged -label:merge sort:merged merged:><YEAR-MONTH-DAY-PREVIOUS-RELEASE> -milestone:<RELEASE_TAG>`
+
+3. Review all PRs for the new release and update their titles as needed according to the Galaxy contributing guidelines, particularly point 6: https://github.com/galaxyproject/galaxy/blob/dev/CONTRIBUTING.md#how-to-contribute.
+
+Search for: `is:pr milestone:<RELEASE_TAG>`

--- a/TASKS.md
+++ b/TASKS.md
@@ -88,7 +88,18 @@ cd <GALAXY_ROOT>
 
 5. Re-run the above command without the `--dry-run` argument to actually open a release publication issue on `GitHub`.
 
-### Step 7: Are we good to freeze?
+### Step 7: Create Milestone for Future Release
+Using the GitHub interface, create a new milestone.
+
+1. Go to [https://github.com/galaxyproject/galaxy/milestones](https://github.com/galaxyproject/galaxy/milestones)
+2. Click **New milestone** and create a new milestone
+3. Note the milestone number from the URL:  
+   `https://github.com/galaxyproject/galaxy/milestone/<MILESTONE_NUMBER>`
+4. Edit [`.github/workflows/maintenance_bot.yaml`](https://github.com/galaxyproject/galaxy/blob/dev/.github/workflows/maintenance_bot.yaml) and update `<MILESTONE_NUMBER>` so new pull requests are tagged with the correct milestone
+5. Open a pull request to update the milestone.  
+   Example: [https://github.com/galaxyproject/galaxy/pull/20946](https://github.com/galaxyproject/galaxy/pull/20946)
+
+### Step 8: Are we good to freeze?
 
 Use the following filter to identify PRs without `kind/*` labels and assign the appropriate `kind/*` labels. This helps compile the final list of PRs for the current milestone that must be included in the release by the freeze date.
 
@@ -96,7 +107,7 @@ Use the following filter to identify PRs without `kind/*` labels and assign the 
 2. Search for: `is:open is:pr milestone:<RELEASE_TAG> -label:"kind/feature" -label:"kind/bug" -label:"kind/enhancement" -label:"kind/refactoring" -label:dependencies`
 3. Assign proper labels, and milestones to these PRs
 
-### Step 8: Review of Blockers
+### Step 9: Review of Blockers
 
 Write the following message to above channels:
 
@@ -106,7 +117,7 @@ Write the following message to above channels:
 > We still have <NUMBER_OF_OPEN_PRS> PRs from the freeze list that need to be merged before we can branch. It would be great if folks can review these remaining ones as soon as possible, so we can actually branch. Even if a PR is assigned to someone else, feel free to jump in with a review!
 > Link to the remaining PRs: https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+-label%3A%22kind%2Fbug%22+-is%3Adraft+milestone%3A<RELEASE_TAG>
 
-### Step 9: Review Merged PRs
+### Step 10: Review Merged PRs
 
 1. Go to: [https://github.com/galaxyproject/galaxy/pulls](https://github.com/galaxyproject/galaxy/pulls)
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -30,8 +30,10 @@ One week before the freeze, we hold the Freeze Meeting, usually during a weekly 
 
 To list all PRs for discussion:
 
-1. Go to: https://github.com/galaxyproject/galaxy/pulls
-2. Search for: `is:open is:pr milestone:<RELEASE_TAG> -label:kind/bug -is:draft`
+1. Go to: https://github.com/galaxyproject/galaxy/pulls, search for:
+```
+is:open is:pr milestone:<RELEASE_TAG> -label:kind/bug -is:draft
+```
 
 ### Step 4: Install Galaxy Release Utility
 Much of the release process has been automated with `galaxy-release-util`. In the following section, we show how to install it and ensure that your installed version is up-to-date.

--- a/TASKS.md
+++ b/TASKS.md
@@ -84,9 +84,14 @@ Using `galaxy-release-util`, we are now ready to publish the release issue on `G
 cd <GALAXY_ROOT>
 ```
 
-3. Review the release issue output in the terminal (`--dry-run`):
-```bash
-galaxy-release-util create-release-issue <RELEASE_TAG> --freeze-date 'YEAR-MONTH-DAY' --next-version <NEXT_RELEASE_TAG> --dry-run y --release-date 'YEAR-MONTH-DAY'
-```
+3. Review the release issue output in the terminal (`--dry-run`): `galaxy-release-util create-release-issue <RELEASE_TAG> --freeze-date 'YEAR-MONTH-DAY' --next-version <NEXT_RELEASE_TAG> --dry-run y --release-date 'YEAR-MONTH-DAY'`
 
-4. Re-run the above command without the `--dry-run` argument to actually open a release publication issue on `GitHub`.
+5. Re-run the above command without the `--dry-run` argument to actually open a release publication issue on `GitHub`.
+
+### Step 7: Are we good to freeze?
+
+Use the following filter to identify PRs without `kind/*` labels and assign the appropriate `kind/*` labels. This helps compile the final list of PRs for the current milestone that must be included in the release by the freeze date.
+
+1. Go to: [https://github.com/galaxyproject/galaxy/pulls](https://github.com/galaxyproject/galaxy/pulls)  
+2. Search for: `is:open is:pr milestone:<RELEASE_TAG> -label:"kind/feature" -label:"kind/bug" -label:"kind/enhancement" -label:"kind/refactoring" -label:dependencies`
+3. Assign proper labels, and milestones to these PRs

--- a/TASKS.md
+++ b/TASKS.md
@@ -74,7 +74,7 @@ We ensure that all previous release publication issues are closed before publish
  
 3. Select and close previous publication issues
 
-### Step 6: Open Release Publication Issue
+### Step 6: Open New Release Publication Issue
 Using `galaxy-release-util`, we are now ready to publish the release issue on `GitHub`, which will publicly track the release publication stages using a checklist of items.
 
 1. Make sure that you are in your `galaxy-release-util` virtual environment.

--- a/TASKS.md
+++ b/TASKS.md
@@ -30,7 +30,7 @@ One week before the freeze, we hold the Freeze Meeting, usually during a weekly 
 
 To list all PRs for discussion:
 
-1. Go to: [https://github.com/galaxyproject/galaxy/pulls](https://github.com/galaxyproject/galaxy/pulls)  
+1. Go to: https://github.com/galaxyproject/galaxy/pulls
 2. Search for: `is:open is:pr milestone:<RELEASE_TAG> -label:kind/bug -is:draft`
 
 ### Step 4: Install Galaxy Release Utility
@@ -68,7 +68,7 @@ which galaxy-release-util
 ### Step 5: Close Previous Release Publication Issues
 We ensure that all previous release publication issues are closed before publishing a new one.
 
-1. Go to: [https://github.com/galaxyproject/galaxy/issues](https://github.com/galaxyproject/galaxy/issues)
+1. Go to: https://github.com/galaxyproject/galaxy/issues
    
 2. Search for: `Publication of Galaxy Release`
  
@@ -91,19 +91,19 @@ cd <GALAXY_ROOT>
 ### Step 7: Create Milestone for Future Release
 Using the GitHub interface, create a new milestone.
 
-1. Go to [https://github.com/galaxyproject/galaxy/milestones](https://github.com/galaxyproject/galaxy/milestones)
+1. Go to https://github.com/galaxyproject/galaxy/milestones
 2. Click **New milestone** and create a new milestone
 3. Note the milestone number from the URL:  
    `https://github.com/galaxyproject/galaxy/milestone/<MILESTONE_NUMBER>`
-4. Edit [`.github/workflows/maintenance_bot.yaml`](https://github.com/galaxyproject/galaxy/blob/dev/.github/workflows/maintenance_bot.yaml) and update `<MILESTONE_NUMBER>` so new pull requests are tagged with the correct milestone
+4. Edit https://github.com/galaxyproject/galaxy/blob/dev/.github/workflows/maintenance_bot.yaml and update `<MILESTONE_NUMBER>` so new pull requests are tagged with the correct milestone
 5. Open a pull request to update the milestone.  
-   Example: [https://github.com/galaxyproject/galaxy/pull/20946](https://github.com/galaxyproject/galaxy/pull/20946)
+   Example: https://github.com/galaxyproject/galaxy/pull/20946
 
 ### Step 8: Are we good to freeze?
 
 Use the following filter to identify PRs without `kind/*` labels and assign the appropriate `kind/*` labels. This helps compile the final list of PRs for the current milestone that must be included in the release by the freeze date.
 
-1. Go to: [https://github.com/galaxyproject/galaxy/pulls](https://github.com/galaxyproject/galaxy/pulls)  
+1. Go to: https://github.com/galaxyproject/galaxy/pulls
 2. Search for: `is:open is:pr milestone:<RELEASE_TAG> -label:"kind/feature" -label:"kind/bug" -label:"kind/enhancement" -label:"kind/refactoring" -label:dependencies`
 3. Assign proper labels, and milestones to these PRs
 
@@ -119,7 +119,7 @@ Write the following message to above channels:
 
 ### Step 10: Review Merged PRs
 
-1. Go to: [https://github.com/galaxyproject/galaxy/pulls](https://github.com/galaxyproject/galaxy/pulls)
+1. Go to: https://github.com/galaxyproject/galaxy/pulls
 
 2. Identify all PRs merged since the last release that are missing the appropriate tag and assign the correct tag.
 
@@ -128,3 +128,56 @@ Search for: `is:pr is:merged -label:merge sort:merged merged:><YEAR-MONTH-DAY-PR
 3. Review all PRs for the new release and update their titles as needed according to the Galaxy contributing guidelines, particularly point 6: https://github.com/galaxyproject/galaxy/blob/dev/CONTRIBUTING.md#how-to-contribute.
 
 Search for: `is:pr milestone:<RELEASE_TAG>`
+
+### Step 11: Update Database Revision
+
+1. Switch to your `dev` branch and ensure it is up to date, for example by running:  
+   `git pull upstream dev`
+2. Run:  
+   `./manage_db.sh version`
+3. Note the first revision identifier `<DB_REVISION> (gxy) (head)`.
+4. Edit `lib/galaxy/model/migrations/dbrevisions.py` and add a new entry:  
+   `"<RELEASE_TAG>": "<DB_REVISION>",`
+5. Open a pull request to update the database revision.  
+   Example: https://github.com/galaxyproject/galaxy/pull/21017
+
+### Step 12: Merge Previous Release into `dev`
+
+1. Check out the previous release:  
+   `git checkout release_<PREVIOUS_RELEASE_TAG>`
+2. Ensure the previous release is up to date:  
+   `git pull upstream release_<PREVIOUS_RELEASE_TAG>`
+3. Check out `dev` and merge the previous release into it:  
+   `git checkout dev`  
+   `git merge release_<PREVIOUS_RELEASE_TAG>`  
+   `git commit -a -m "Merge <PREVIOUS_RELEASE_TAG> into dev"`  
+   `git push`
+4. Open a pull request against `dev` and merge it.
+
+### Step 13: Create Release Candidate Branches
+
+1. Check out the `dev` branch and pull the latest changes:  
+   `git checkout dev`  
+   `git pull upstream dev`
+
+2. Run the release creation command:  
+   `make release-create-rc`
+
+3. This command creates two branches:
+
+   **a. `version-<FUTURE_RELEASE_TAG>.dev`**  
+   Title: `Version <FUTURE_RELEASE_TAG>.dev`  
+   - Open a pull request **against `dev`**.  
+     Example: [https://github.com/galaxyproject/galaxy/pull/21020](https://github.com/galaxyproject/galaxy/pull/21020)  
+   - **Note:** Manually verify this step because it:  
+     1. may generate the wrong future release number  
+     2. adds a client-hash-build file that must be removed
+
+   **b. `version-<RELEASE_TAG>.rc1`**  
+   Title: `Update version to <RELEASE_TAG>.rc1`  
+   - Open a pull request **against `galaxyproject:release_<RELEASE_TAG>`**.  
+     Example: [https://github.com/galaxyproject/galaxy/pull/21019](https://github.com/galaxyproject/galaxy/pull/21019)
+
+
+   
+   

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,68 @@
+# Galaxy Release Manager Tasks
+
+This document provides a step-by-step guide for managing Galaxy releases. It outlines the key responsibilities of the release manager, from determining the freeze date to preparing and executing the release. Each step includes practical instructions, recommended commands, and communication guidelines to ensure a smooth and coordinated release process.
+
+## Tasks
+
+### Step 1: Determine Freeze Date
+
+Discuss and agree on an appropriate freeze date (DATE_OF_FREEZE_MEETING) with the team during a dev meeting.
+
+### Step 2: Announce Freeze Meeting
+
+Two weeks before the actual freeze, we announce the freeze meeting for the upcoming week.
+
+1. Send the following message:
+
+```
+🗓️ Freeze Meeting on <DATE_OF_FREEZE_MEETING>
+
+Hello everyone, we will meet on <DATE_OF_FREEZE_MEETING> for the Freeze Meeting, one week before the actual freeze. We will review open PRs, decide what will be included in the <RELEASE_TAG> release, and assign reviewers to ensure merges are completed by the freeze date. If you have outstanding PRs, please make sure they are set to ready-for-review before the meeting.
+```
+
+2. To these channels:
+
+- https://matrix.to/#/#galaxyproject_ui-ux:gitter.im
+- https://matrix.to/#/#galaxyproject_backend:gitter.im
+- ...
+
+
+### Step 3: The Freeze Meeting
+One week before the freeze, we hold the Freeze Meeting, usually during a weekly dev meeting. In this meeting, we review open PRs, decide what will be included in the <RELEASE_TAG> release, and assign reviewers to ensure PRs are merged by the freeze date. Focus on non-draft, non-bug PRs for this discussion. 
+
+To list all PRs for discussion:
+
+1. Go to: [https://github.com/galaxyproject/galaxy/pulls](https://github.com/galaxyproject/galaxy/pulls)  
+2. Search for: `is:open is:pr milestone:<RELEASE_TAG> -label:kind/bug -is:draft`
+
+### Step 4: Install Galaxy Release Utility
+Much of the release process has been automated with `galaxy-release-util`. In the following section, we show how to install it and ensure that your installed version is up-to-date.
+
+1. If not already cloned:
+
+```bash
+git clone https://github.com/galaxyproject/galaxy-release-util
+```
+
+2. Update with latest changes:
+
+```bash
+cd galaxy-release-util
+git fetch upstream
+```
+
+3. Install and activate:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+4. Verify version:
+
+Use the `which` command to confirm that the version of `galaxy-release-util` being used is the one installed in the your virtual environment.
+
+```bash
+which galaxy-release-util
+```

--- a/TASKS.md
+++ b/TASKS.md
@@ -84,7 +84,10 @@ Using `galaxy-release-util`, we are now ready to publish the release issue on `G
 cd <GALAXY_ROOT>
 ```
 
-3. Review the release issue output in the terminal (`--dry-run yes`): `galaxy-release-util create-release-issue <RELEASE_TAG> --freeze-date 'YEAR-MONTH-DAY' --release-date 'YEAR-MONTH-DAY' --next-version <NEXT_RELEASE_TAG> --dry-run yes`
+3. Review the release issue output in the terminal (`--dry-run yes`):
+```
+galaxy-release-util create-release-issue <RELEASE_TAG> --freeze-date 'YEAR-MONTH-DAY' --release-date 'YEAR-MONTH-DAY' --next-version <NEXT_RELEASE_TAG> --dry-run yes
+```
 
 4. Re-run the above command without the `--dry-run` argument to actually open a release publication issue on `GitHub`.
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -101,11 +101,13 @@ Using the GitHub interface, create a new milestone.
 2. Click **New milestone** and create a new milestone
 
 3. Note the milestone number from the URL:  
-   `https://github.com/galaxyproject/galaxy/milestone/<MILESTONE_NUMBER>`
+```
+https://github.com/galaxyproject/galaxy/milestone/<MILESTONE_NUMBER>
+```
 
-4. Edit https://github.com/galaxyproject/galaxy/blob/dev/.github/workflows/maintenance_bot.yaml and update `<MILESTONE_NUMBER>` so new pull requests are tagged with the correct milestone
+5. Edit https://github.com/galaxyproject/galaxy/blob/dev/.github/workflows/maintenance_bot.yaml and update `<MILESTONE_NUMBER>` so new pull requests are tagged with the correct milestone
 
-5. Open a pull request to update the milestone.  
+6. Open a pull request to update the milestone.  
    Example: https://github.com/galaxyproject/galaxy/pull/20946
 
 ### Step 8: Are we good to freeze?

--- a/TASKS.md
+++ b/TASKS.md
@@ -6,7 +6,7 @@ This document provides a step-by-step guide for managing Galaxy releases. It out
 
 ### Step 1: Determine Freeze and Release Date
 
-Discuss and agree on an appropriate freeze date (DATE_OF_FREEZE) and anticipated release date (RELEASE_DATE) with the team during a dev meeting.
+Discuss and agree on an appropriate freeze date (FREEZE_DATE) and anticipated release date (RELEASE_DATE) with the team during a dev meeting.
 
 ### Step 2: Announce Freeze Meeting
 
@@ -14,9 +14,9 @@ Two weeks before the actual freeze, we announce the freeze meeting for the upcom
 
 1. Send the following message:
 
->🗓️ Freeze Meeting on <DATE_OF_FREEZE_MEETING>
+>🗓️ Freeze Meeting on <FREEZE_MEETING_DATE>
 >
->We will meet on <DATE_OF_FREEZE_MEETING> for the Freeze Meeting, one week before the actual freeze. We will review open PRs, decide what will be included in the <RELEASE_TAG> release, and assign reviewers to ensure merges are completed by the freeze date. If you have outstanding PRs, please make sure they are set to ready-for-review before the meeting.
+>We will meet on <FREEZE_MEETING_DATE> for the Freeze Meeting, one week before the actual freeze. We will review open PRs, decide what will be included in the <RELEASE_TAG> release, and assign reviewers to ensure merges are completed by the freeze date. If you have outstanding PRs, please make sure they are set to ready-for-review before the meeting.
 
 2. To these channels:
 
@@ -46,7 +46,7 @@ git clone https://github.com/galaxyproject/galaxy-release-util
 
 ```bash
 cd galaxy-release-util
-git fetch upstream
+git pull
 ```
 
 3. Install and activate:

--- a/TASKS.md
+++ b/TASKS.md
@@ -84,7 +84,7 @@ Using `galaxy-release-util`, we are now ready to publish the release issue on `G
 cd <GALAXY_ROOT>
 ```
 
-3. Review the release issue output in the terminal (`--dry-run`): `galaxy-release-util create-release-issue <RELEASE_TAG> --freeze-date 'YEAR-MONTH-DAY' --next-version <NEXT_RELEASE_TAG> --dry-run y --release-date 'YEAR-MONTH-DAY'`
+3. Review the release issue output in the terminal (`--dry-run yes`): `galaxy-release-util create-release-issue <RELEASE_TAG> --freeze-date 'YEAR-MONTH-DAY' --release-date 'YEAR-MONTH-DAY' --next-version <NEXT_RELEASE_TAG> --dry-run yes`
 
 5. Re-run the above command without the `--dry-run` argument to actually open a release publication issue on `GitHub`.
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -86,16 +86,20 @@ cd <GALAXY_ROOT>
 
 3. Review the release issue output in the terminal (`--dry-run yes`): `galaxy-release-util create-release-issue <RELEASE_TAG> --freeze-date 'YEAR-MONTH-DAY' --release-date 'YEAR-MONTH-DAY' --next-version <NEXT_RELEASE_TAG> --dry-run yes`
 
-5. Re-run the above command without the `--dry-run` argument to actually open a release publication issue on `GitHub`.
+4. Re-run the above command without the `--dry-run` argument to actually open a release publication issue on `GitHub`.
 
 ### Step 7: Create Milestone for Future Release
 Using the GitHub interface, create a new milestone.
 
 1. Go to https://github.com/galaxyproject/galaxy/milestones
+  
 2. Click **New milestone** and create a new milestone
+
 3. Note the milestone number from the URL:  
    `https://github.com/galaxyproject/galaxy/milestone/<MILESTONE_NUMBER>`
+
 4. Edit https://github.com/galaxyproject/galaxy/blob/dev/.github/workflows/maintenance_bot.yaml and update `<MILESTONE_NUMBER>` so new pull requests are tagged with the correct milestone
+
 5. Open a pull request to update the milestone.  
    Example: https://github.com/galaxyproject/galaxy/pull/20946
 
@@ -103,9 +107,12 @@ Using the GitHub interface, create a new milestone.
 
 Use the following filter to identify PRs without `kind/*` labels and assign the appropriate `kind/*` labels. This helps compile the final list of PRs for the current milestone that must be included in the release by the freeze date.
 
-1. Go to: https://github.com/galaxyproject/galaxy/pulls
-2. Search for: `is:open is:pr milestone:<RELEASE_TAG> -label:"kind/feature" -label:"kind/bug" -label:"kind/enhancement" -label:"kind/refactoring" -label:dependencies`
-3. Assign proper labels, and milestones to these PRs
+1. Go to: https://github.com/galaxyproject/galaxy/pulls and search for:
+```
+is:open is:pr milestone:<RELEASE_TAG> -label:"kind/feature" -label:"kind/bug" -label:"kind/enhancement" -label:"kind/refactoring" -label:dependencies
+```
+
+2. Assign proper labels, and milestones to these PRs
 
 ### Step 9: Review of Blockers
 
@@ -121,47 +128,72 @@ Write the following message to above channels:
 
 1. Go to: https://github.com/galaxyproject/galaxy/pulls
 
-2. Identify all PRs merged since the last release that are missing the appropriate tag and assign the correct tag.
+2. Identify all PRs merged since the last release that are missing the appropriate tag and assign the correct tag. Search for:
+```
+is:pr is:merged -label:merge sort:merged merged:><YEAR-MONTH-DAY-PREVIOUS-RELEASE> -milestone:<RELEASE_TAG>
+```
 
-Search for: `is:pr is:merged -label:merge sort:merged merged:><YEAR-MONTH-DAY-PREVIOUS-RELEASE> -milestone:<RELEASE_TAG>`
-
-3. Review all PRs for the new release and update their titles as needed according to the Galaxy contributing guidelines, particularly point 6: https://github.com/galaxyproject/galaxy/blob/dev/CONTRIBUTING.md#how-to-contribute.
-
-Search for: `is:pr milestone:<RELEASE_TAG>`
+4. Review all PRs for the new release and update their titles as needed according to the Galaxy contributing guidelines, particularly point 6: https://github.com/galaxyproject/galaxy/blob/dev/CONTRIBUTING.md#how-to-contribute. Search for:
+```
+is:pr milestone:<RELEASE_TAG>
+```
 
 ### Step 11: Update Database Revision
 
 1. Switch to your `dev` branch and ensure it is up to date, for example by running:  
-   `git pull upstream dev`
+```bash
+git pull upstream dev
+```
+
 2. Run:  
-   `./manage_db.sh version`
+```bash
+./manage_db.sh version
+```
+
 3. Note the first revision identifier `<DB_REVISION> (gxy) (head)`.
+
 4. Edit `lib/galaxy/model/migrations/dbrevisions.py` and add a new entry:  
-   `"<RELEASE_TAG>": "<DB_REVISION>",`
-5. Open a pull request to update the database revision.  
+```
+"<RELEASE_TAG>": "<DB_REVISION>",
+```
+
+6. Open a pull request to update the database revision.  
    Example: https://github.com/galaxyproject/galaxy/pull/21017
 
 ### Step 12: Merge Previous Release into `dev`
 
 1. Check out the previous release:  
-   `git checkout release_<PREVIOUS_RELEASE_TAG>`
+```bash
+git checkout release_<PREVIOUS_RELEASE_TAG>
+```
+
 2. Ensure the previous release is up to date:  
-   `git pull upstream release_<PREVIOUS_RELEASE_TAG>`
+```bash
+git pull upstream release_<PREVIOUS_RELEASE_TAG>
+```
+
 3. Check out `dev` and merge the previous release into it:  
-   `git checkout dev`  
-   `git merge release_<PREVIOUS_RELEASE_TAG>`  
-   `git commit -a -m "Merge <PREVIOUS_RELEASE_TAG> into dev"`  
-   `git push`
-4. Open a pull request against `dev` and merge it.
+```bash
+git checkout dev
+git merge release_<PREVIOUS_RELEASE_TAG>
+git commit -a -m "Merge <PREVIOUS_RELEASE_TAG> into dev"
+git push
+```
+
+6. Open a pull request against `dev` and merge it.
 
 ### Step 13: Create Release Candidate Branches
 
 1. Check out the `dev` branch and pull the latest changes:  
-   `git checkout dev`  
-   `git pull upstream dev`
+```bash
+git checkout dev
+git pull upstream dev
+```
 
 2. Run the release creation command:  
-   `make release-create-rc`
+```bash
+make release-create-rc
+```
 
 3. This command creates two branches:
 

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -204,7 +204,7 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
 
           make release-create-rc
 
-    - [ ] Open pull requests from your fork of branch ``version-${version}`` to upstream ``release_${version}`` and of ``version-${next_version}.dev`` to ``dev``.
+    - [ ] Open pull requests from your fork of branch ``version-${version}.rc1`` to upstream ``release_${version}`` and of ``version-${next_version}.dev`` to ``dev``.
 
 - [ ] **Run tool and workflow tests:**
 

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -206,19 +206,6 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
 
     - [ ] Open pull requests from your fork of branch ``version-${version}`` to upstream ``release_${version}`` and of ``version-${next_version}.dev`` to ``dev``.
 
-- [ ] **Issue Review Timeline Notes**
-
-    - [ ] Ensure any security fixes will be ready prior to ${freeze_date} + 2 weeks, to allow time for notification prior to release.
-    - [ ] Ensure ownership of outstanding bugfixes and track progress during freeze.
-
-- [ ] **Deploy and Test Release on galaxy-test**
-
-    - [ ] Update test.galaxyproject.org to ensure it is running the ``release_${version}`` branch.
-    - [ ] Request that testtoolshed.g2.bx.psu.edu is updated to ``${version}``.
-    - [ ] Conduct formal release testing on test.galaxyproject.org (see ${version} release testing plan).
-    - [ ] Ensure all critical bugs detected during release testing have been fixed.
-
-
 - [ ] **Run tool and workflow tests:**
 
     - [ ] IUC:
@@ -242,6 +229,18 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
                 - Check if there's an issue open. If not, open a new issue.
         - [ ] Add/Update tests against IWC.
           e.g.: https://github.com/galaxyproject/iwc/pull/867
+
+- [ ] **Issue Review Timeline Notes**
+
+    - [ ] Ensure any security fixes will be ready prior to ${freeze_date} + 2 weeks, to allow time for notification prior to release.
+    - [ ] Ensure ownership of outstanding bugfixes and track progress during freeze.
+
+- [ ] **Deploy and Test Release on galaxy-test**
+
+    - [ ] Update test.galaxyproject.org to ensure it is running the ``release_${version}`` branch.
+    - [ ] Request that testtoolshed.g2.bx.psu.edu is updated to ``${version}``.
+    - [ ] Conduct formal release testing on test.galaxyproject.org (see ${version} release testing plan).
+    - [ ] Ensure all critical bugs detected during release testing have been fixed.
 
 - [ ] **Create Release Notes**
 

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -193,7 +193,7 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
 
 - [ ] **Branch Release**
 
-    - [ ] Add latest database revision identifier (for ``release_${version}`` and ``${version}``) to ``REVISION_TAGS`` in ``galaxy/model/migrations/dbscript.py``.
+    - [ ] Add latest database revision identifier (for ``release_${version}`` and ``${version}``) to ``REVISION_TAGS`` in ``lib/galaxy/model/migrations/dbrevisions.py``.
 
     - [ ] Merge the latest release into dev and push upstream.
 

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -282,7 +282,7 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
     - [ ] Ensure previous release is merged into current. [GitHub branch comparison](https://github.com/galaxyproject/galaxy/compare/release_${version}...release_${previous_version})
     - [ ] Create the first point release (v${version}.0) using the instructions at https://docs.galaxyproject.org/en/master/dev/create_release.html#creating-galaxy-point-releases
 
-          galaxy-release-util create-release --new-version ${version}.0 --last-commit [insert latest tag, e.g. v24.1.4]
+          galaxy-release-util create-release --new-version ${version}.0 --last-commit <LAST_RELEASE_TAG>
 
     - [ ] Open PR against planemo with a pin to the new packages
 


### PR DESCRIPTION
@jdavcs and @ahmedhamidawan have compiled detailed release manager instructions and notes in a Google Docs document. This PR converts and organizes those instructions into structured markdown and adds them to this repository.