### PR TITLE
Update galaxy-client dependency version during point releases

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -17,9 +17,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox tox-gh>=1.2
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+    - name: Install tox
+      run: uv tool install tox --with tox-uv
     - name: Test with tox
       run: tox

--- a/galaxy_release_util/point_release.py
+++ b/galaxy_release_util/point_release.py
@@ -714,6 +714,8 @@ def update_client_version(galaxy_root: Path, new_version: Version, modified_path
         modified_paths.append(root_package_json)
         root_package_json_dict = json.loads(root_package_json.read_text())
         root_package_json_dict["version"] = str(new_version)
+        # Also update the dependency version to match (use exact version, no semver range)
+        root_package_json_dict["dependencies"]["@galaxyproject/galaxy-client"] = str(new_version)
         root_package_json.write_text(f"{json.dumps(root_package_json_dict, indent=2)}\n")
 
 


### PR DESCRIPTION
When creating a point release, the root `package.json` dependency on `@galaxyproject/galaxy-client` was not being updated to match the new version.

On `release_25.0` with dependency `"^25.0.4"`, `yarn install` resolved to `25.1.0` (from dev) instead of `25.0.x` because the caret range allows `>=25.0.4 <26.0.0`.

This updates the dependency version alongside the package version, using an exact version (no semver range).