### PR TITLE
Add release config YAML and extend CLI flags

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -7,6 +7,8 @@ This document provides a step by step guide for managing Galaxy releases. It out
 * RELEASE_TAG: the release being prepared, for example 26.0
 * PREVIOUS_RELEASE_TAG: the last published release, for example 25.1
 * NEXT_RELEASE_TAG: the next planned release, for example 26.1
+* FREEZE_DATE: the date the release branch is frozen, for example 2026-01-27
+* RELEASE_DATE: the anticipated publication date, for example 2026-02-17
 
 ## Tasks
 
@@ -221,7 +223,7 @@ Send the following message:
 >
 > As of today, we are officially frozen for <RELEASE_TAG>. No new features or enhancements should be added to the <RELEASE_TAG> milestone after this point.
 > We still have <NUMBER_OF_OPEN_PRS> pull requests from the freeze list that must be merged before we can branch. Reviews are appreciated so we can proceed with branching.
-> Remaining PRs: [https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+-label%3A%22kind%2Fbug%22+-is%3Adraft+milestone%3A](https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+-label%3A%22kind%2Fbug%22+-is%3Adraft+milestone%3A)<RELEASE_TAG>
+> Remaining PRs: https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+-label%3A%22kind%2Fbug%22+-is%3Adraft+milestone%3A<RELEASE_TAG>
 
 ---
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -369,7 +369,7 @@ Reach out per email to assemble the testing team for the upcoming release:
 >**<DAY_NAME> <MONTH_NAME> <DAY_COUNT>** through **<DAY_NAME> <MONTH_NAME> <DAY_COUNT>**
 >
 >**Time commitment:**
->Approximately four hours per day. Testing consists of working through as many assigned PRs as time permits. There will be one short kick off meeting immediately before testing begins.
+>Approximately 1-2 hours per day. Testing consists of working through as many assigned PRs as time permits. There will be one short kick off meeting immediately before testing begins.
 >
 >**What release testing involves:**
 >Release testing focuses on validating Galaxy GitHub pull requests. Each PR represents either a new feature, an enhancement, or a bug fix. Testing means exercising the changes as a user would and verifying that they behave correctly and do not introduce regressions. A curated list of PRs will be provided, and detailed guidance on the testing workflow and PR selection will be covered in the kick off meeting.

--- a/TASKS.md
+++ b/TASKS.md
@@ -355,4 +355,31 @@ Send this message to at least the following channels:
 
 ---
 
-### Step 18: Continue with Release Issue
+### Step 18: Assemble Testing Team
+
+Reach out per email to assemble the testing team for the upcoming release:
+
+>**Galaxy <RELEASE_TAG> Release Testing**
+>
+>Hi,
+>
+>I am organizing testing for the upcoming Galaxy release and would like to ask whether you would be available to participate.
+>
+>**Testing window:**
+>**<DAY_NAME> <MONTH_NAME> <DAY_COUNT>** through **<DAY_NAME> <MONTH_NAME> <DAY_COUNT>**
+>
+>**Time commitment:**
+>Approximately four hours per day. Testing consists of working through as many assigned PRs as time permits. There will be one short kick off meeting immediately before testing begins.
+>
+>**What release testing involves:**
+>Release testing focuses on validating Galaxy GitHub pull requests. Each PR represents either a new feature, an enhancement, or a bug fix. Testing means exercising the changes as a user would and verifying that they behave correctly and do not introduce regressions. A curated list of PRs will be provided, and detailed guidance on the testing workflow and PR selection will be covered in the kick off meeting.
+>
+>I will be available throughout the testing period, and the galaxyproject/release-testing channel on Element will be used for coordination and questions.
+>
+>If you are able to participate, I will follow up with concrete details.
+>
+>Thanks!
+
+---
+
+### Step 19: Continue with Release Issue

--- a/TASKS.md
+++ b/TASKS.md
@@ -135,7 +135,7 @@ freeze-date: "<FREEZE_DATE>"
 release-date: "<RELEASE_DATE>"
 ```
 
-All fields except `freeze-date` are required. Two optional fields, `owner` and `repo`, default to `"galaxyproject"` and `"galaxy"` respectively. Override them only when working with a private or forked repository.
+All fields are required. Two optional fields, `owner` and `repo`, default to `"galaxyproject"` and `"galaxy"` respectively. Override them only when working with a private or forked repository.
 
 3. Commit this file to the repository so it is available for all subsequent release commands.
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -113,7 +113,33 @@ export GITHUB_AUTH=<TOKEN>
 
 ---
 
-### Step 6: Open New Release Publication Issue
+### Step 6: Create Release Config YAML
+
+All release metadata is stored in a YAML config file. This file is required by `galaxy-release-util` commands and replaces the individual `--freeze-date`, `--release-date`, and `--next-version` flags.
+
+1. Change to your Galaxy root directory:
+
+```bash
+cd <GALAXY_ROOT>
+```
+
+2. Create the release config file at `doc/source/releases/release_<RELEASE_TAG>.yml`:
+
+```yaml
+current-version: "<RELEASE_TAG>"
+previous-version: "<PREVIOUS_RELEASE_TAG>"
+next-version: "<NEXT_RELEASE_TAG>"
+freeze-date: "<FREEZE_DATE>"
+release-date: "<RELEASE_DATE>"
+```
+
+All fields except `freeze-date` are required. Two optional fields, `owner` and `repo`, default to `"galaxyproject"` and `"galaxy"` respectively. Override them only when working with a private or forked repository.
+
+3. Commit this file to the repository so it is available for all subsequent release commands.
+
+---
+
+### Step 7: Open New Release Publication Issue
 
 Using `galaxy-release-util`, create the release publication issue that tracks all publication tasks for the current release.
 
@@ -128,14 +154,16 @@ cd <GALAXY_ROOT>
 3. Review the generated release issue content:
 
 ```bash
-galaxy-release-util create-release-issue <RELEASE_TAG> --freeze-date 'YEAR-MONTH-DAY' --release-date 'YEAR-MONTH-DAY' --next-version <NEXT_RELEASE_TAG> --dry-run yes
+galaxy-release-util create-release-issue <RELEASE_TAG> --galaxy-root . --dry-run
 ```
+
+To use a config file at a non-default location, add `--release-config /path/to/config.yml`.
 
 4. Re run the command without `--dry-run` to open the issue on GitHub.
 
 ---
 
-### Step 7: Create Milestone for Next Release
+### Step 8: Create Milestone for Next Release
 
 Create a milestone for the next release so new pull requests are tagged correctly.
 
@@ -155,7 +183,7 @@ https://github.com/galaxyproject/galaxy/milestone/<MILESTONE_NUMBER>
 
 ---
 
-### Step 8: Freeze Meeting
+### Step 9: Freeze Meeting
 
 One week before the freeze, hold the Freeze Meeting, usually during a weekly dev meeting. In this meeting, review open pull requests, decide what will be included in the <RELEASE_TAG> release, and assign reviewers to ensure merges complete before the freeze. Milestone decisions made here are binding for the freeze.
 
@@ -169,7 +197,7 @@ is:open is:pr milestone:<RELEASE_TAG> -label:kind/bug -is:draft
 
 ---
 
-### Step 9: Final Pre Freeze Milestone and Label Audit
+### Step 10: Final Pre Freeze Milestone and Label Audit
 
 Before freezing, ensure all pull requests in the milestone have appropriate `kind/*` labels and correct milestone assignment.
 
@@ -183,7 +211,7 @@ is:open is:pr milestone:<RELEASE_TAG> -label:"kind/feature" -label:"kind/bug" -l
 
 ---
 
-### Step 10: Confirm and Announce Freeze
+### Step 11: Confirm and Announce Freeze
 
 After completing the audit, the release manager confirms the freeze and announces it.
 
@@ -197,7 +225,7 @@ Send the following message:
 
 ---
 
-### Step 11: Review Merged Pull Requests
+### Step 12: Review Merged Pull Requests
 
 Ensure all merged pull requests for the release are correctly labeled and titled to support accurate release notes.
 
@@ -213,7 +241,7 @@ is:pr is:merged -label:merge sort:merged merged:><YEAR-MONTH-DAY-PREVIOUS-RELEAS
 
 ---
 
-### Step 12: Update Database Revision
+### Step 13: Update Database Revision
 
 Update the database revision mapping for the release. This change must land before branching.
 
@@ -241,7 +269,7 @@ git pull upstream dev
 
 ---
 
-### Step 13: Merge Previous Release into dev
+### Step 14: Merge Previous Release into dev
 
 Merge the previous release branch into `dev` to ensure all backported fixes are present.
 
@@ -265,7 +293,7 @@ git push
 
 ---
 
-### Step 14: Create Release Candidate Branches
+### Step 15: Create Release Candidate Branches
 
 Create release candidate and next dev version branches.
 
@@ -301,7 +329,7 @@ Note: These steps may silently fail without producing any branches. Inspect `cat
 
 ---
 
-### Step 15: Create a new GitHub label
+### Step 16: Create a new GitHub label
 
 * Navigate to https://github.com/galaxyproject/galaxy/issues
 * Click on `Labels` and `New label`
@@ -310,7 +338,7 @@ Note: These steps may silently fail without producing any branches. Inspect `cat
 
 ---
 
-### Step 16: Announce Branching
+### Step 17: Announce Branching
 
 Send the following message:
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -115,7 +115,7 @@ export GITHUB_AUTH=<TOKEN>
 
 ### Step 6: Create Release Config YAML
 
-All release metadata is stored in a YAML config file. This file is required by `galaxy-release-util` commands and replaces the individual `--freeze-date`, `--release-date`, and `--next-version` flags.
+All release metadata is defined in a single YAML config file. Once committed, all `galaxy-release-util` commands load it automatically from the default path given a release version.
 
 1. Change to your Galaxy root directory:
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -130,12 +130,11 @@ cd <GALAXY_ROOT>
 ```yaml
 current-version: "<RELEASE_TAG>"
 previous-version: "<PREVIOUS_RELEASE_TAG>"
-next-version: "<NEXT_RELEASE_TAG>"
 freeze-date: "<FREEZE_DATE>"
 release-date: "<RELEASE_DATE>"
 ```
 
-All fields are required. Two optional fields, `owner` and `repo`, default to `"galaxyproject"` and `"galaxy"` respectively. Override them only when working with a private or forked repository.
+All fields are required. Two optional fields, `owner` and `repo`, default to `"galaxyproject"` and `"galaxy"` respectively. Override them only when working with a private or forked repository. The `next-version` value is provided via the `--next-version` CLI flag on commands that require it (e.g. `create-release-issue`, `create-changelog`).
 
 3. Commit this file to the repository so it is available for all subsequent release commands.
 
@@ -156,7 +155,7 @@ cd <GALAXY_ROOT>
 3. Review the generated release issue content:
 
 ```bash
-galaxy-release-util create-release-issue <RELEASE_TAG> --galaxy-root . --dry-run
+galaxy-release-util create-release-issue <RELEASE_TAG> --galaxy-root . --next-version <NEXT_RELEASE_TAG> --dry-run
 ```
 
 To use a config file at a non-default location, add `--release-config /path/to/config.yml`.

--- a/TASKS.md
+++ b/TASKS.md
@@ -323,7 +323,7 @@ b. `version-<RELEASE_TAG>.rc1`
 
 * Title: Update version to <RELEASE_TAG>.rc1
 * Open a pull request against galaxyproject:release_<RELEASE_TAG>.
-*  Example: https://github.com/galaxyproject/galaxy/pull/21019
+* Example: https://github.com/galaxyproject/galaxy/pull/21019
 
 Note: These steps may silently fail without producing any branches. Inspect `cat packages/app/make-dist.log` if branches were not created.
 
@@ -350,3 +350,7 @@ Send this message to at least the following channels:
 
 * [https://matrix.to/#/#galaxyproject_ui-ux:gitter.im](https://matrix.to/#/#galaxyproject_ui-ux:gitter.im)
 * [https://matrix.to/#/#galaxyproject_backend:gitter.im](https://matrix.to/#/#galaxyproject_backend:gitter.im)
+
+---
+
+### Step 18: Continue with Release Issue

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,57 +1,56 @@
 # Galaxy Release Manager Tasks
 
-This document provides a step-by-step guide for managing Galaxy releases. It outlines the key responsibilities of the release manager, from determining the freeze date to preparing and executing the release. Each step includes practical instructions, recommended commands, and communication guidelines to ensure a smooth and coordinated release process.
+This document provides a step by step guide for managing Galaxy releases. It outlines the responsibilities of the release manager from determining the freeze date to preparing and executing the release. Each step includes concrete actions, commands, and communication guidance to ensure a predictable and coordinated release process.
+
+## Terminology
+
+* RELEASE_TAG: the release being prepared, for example 26.0
+* PREVIOUS_RELEASE_TAG: the last published release, for example 25.1
+* NEXT_RELEASE_TAG: the next planned release, for example 26.1
 
 ## Tasks
 
-### Step 1: Determine Freeze and Release Date
+### Step 1: Determine Freeze and Release Dates
 
-Discuss and agree on an appropriate freeze date (FREEZE_DATE) and anticipated release date (RELEASE_DATE) with the team during a dev meeting.
+Discuss and agree on a tentative freeze date (FREEZE_DATE) and anticipated release date (RELEASE_DATE) with the team during a dev meeting. These dates are provisional until confirmed at the Freeze Meeting.
+
+---
 
 ### Step 2: Announce Freeze Meeting
 
-Two weeks before the actual freeze, we announce the freeze meeting for the upcoming week.
+Two weeks before the planned freeze, announce the Freeze Meeting for the following week. The meeting is held one week before the actual freeze.
 
-1. Send the following message:
+Send the following message:
 
->🗓️ Freeze Meeting on <FREEZE_MEETING_DATE>
+> 🗓️ Freeze Meeting on <FREEZE_MEETING_DATE>
 >
->We will meet on <FREEZE_MEETING_DATE> for the Freeze Meeting, one week before the actual freeze. We will review open PRs, decide what will be included in the <RELEASE_TAG> release, and assign reviewers to ensure merges are completed by the freeze date. If you have outstanding PRs, please make sure they are set to ready-for-review before the meeting.
+> We will meet on <FREEZE_MEETING_DATE> for the Freeze Meeting, one week before the actual freeze. We will review open PRs, decide what will be included in the <RELEASE_TAG> release, and assign reviewers to ensure merges are completed by the freeze date. If you have outstanding PRs, please make sure they are set to ready for review before the meeting.
 
-2. To these channels:
+Send this message to at least the following channels:
 
-- https://matrix.to/#/#galaxyproject_ui-ux:gitter.im
-- https://matrix.to/#/#galaxyproject_backend:gitter.im
-- ...
+* [https://matrix.to/#/#galaxyproject_ui-ux:gitter.im](https://matrix.to/#/#galaxyproject_ui-ux:gitter.im)
+* [https://matrix.to/#/#galaxyproject_backend:gitter.im](https://matrix.to/#/#galaxyproject_backend:gitter.im)
 
+---
 
-### Step 3: The Freeze Meeting
-One week before the freeze, we hold the Freeze Meeting, usually during a weekly dev meeting. In this meeting, we review open PRs, decide what will be included in the <RELEASE_TAG> release, and assign reviewers to ensure PRs are merged by the freeze date. Focus on non-draft, non-bug PRs for this discussion. 
+### Step 3: Install Galaxy Release Utility
 
-To list all PRs for discussion:
+Much of the release process is automated using `galaxy-release-util`. Ensure it is installed and up to date.
 
-1. Go to: https://github.com/galaxyproject/galaxy/pulls, search for:
-```
-is:open is:pr milestone:<RELEASE_TAG> -label:kind/bug -is:draft
-```
-
-### Step 4: Install Galaxy Release Utility
-Much of the release process has been automated with `galaxy-release-util`. In the following section, we show how to install it and ensure that your installed version is up-to-date.
-
-1. If not already cloned:
+1. Clone the repository if not already present:
 
 ```bash
 git clone https://github.com/galaxyproject/galaxy-release-util
 ```
 
-2. Update with latest changes:
+2. Update to the latest version:
 
 ```bash
 cd galaxy-release-util
 git pull
 ```
 
-3. Install and activate:
+3. Install and activate the virtual environment:
 
 ```bash
 python -m venv .venv
@@ -59,127 +58,202 @@ source .venv/bin/activate
 pip install -e .
 ```
 
-4. Verify version:
-
-Use the `which` command to confirm that the version of `galaxy-release-util` being used is the one installed in the your virtual environment.
+4. Verify that the correct executable is used:
 
 ```bash
 which galaxy-release-util
 ```
 
-### Step 5: Close Previous Release Publication Issues
-We ensure that all previous release publication issues are closed before publishing a new one.
+All subsequent uses of `galaxy-release-util` are expected to be run from this virtual environment.
 
-1. Go to: https://github.com/galaxyproject/galaxy/issues
-   
+---
+
+### Step 4: Close Previous Release Publication Issues
+
+Ensure all previous release publication issues are closed before starting a new release to avoid ambiguity about which checklist corresponds to the active release.
+
+1. Go to [https://github.com/galaxyproject/galaxy/issues](https://github.com/galaxyproject/galaxy/issues)
+
 2. Search for: `Publication of Galaxy Release`
- 
-3. Select and close previous publication issues
+
+3. Close any previous publication issues that are still open
+
+---
+
+### Step 5: Create and Configure a GitHub Authentication Token
+
+This step enables authenticated access for `galaxy-release-util` to create release issues, milestones, and related metadata on GitHub. Classic tokens are required because fine grained tokens do not currently provide the necessary permissions.
+
+1. Create a classic GitHub personal access token:
+
+   * Navigate to [https://github.com](https://github.com)
+   * Open your profile menu
+   * Select Settings
+   * Select Developer settings
+   * Select Personal access tokens
+   * Select Tokens (classic)
+   * Click Generate new token
+   * Select Generate new token (classic)
+   * Add a descriptive note indicating Galaxy release management
+   * Enable the following scopes:
+
+     * `repo`
+     * `write:packages`
+     * `delete:packages`
+     * `admin:repo_hook`
+   * Generate the token
+
+2. Export the token in your shell environment:
+
+```bash
+export GITHUB_AUTH=<TOKEN>
+```
+
+3. Ensure the variable is available in the same shell session where `galaxy-release-util` will be executed.
+
+---
 
 ### Step 6: Open New Release Publication Issue
-Using `galaxy-release-util`, we are now ready to publish the release issue on `GitHub`, which will publicly track the release publication stages using a checklist of items.
 
-1. Make sure that you are in your `galaxy-release-util` virtual environment.
+Using `galaxy-release-util`, create the release publication issue that tracks all publication tasks for the current release.
 
-2. Enter your Galaxy root directory:
+1. Ensure you are in the `galaxy-release-util` virtual environment.
+
+2. Change to your Galaxy root directory:
+
 ```bash
 cd <GALAXY_ROOT>
 ```
 
-3. Review the release issue output in the terminal (`--dry-run yes`):
-```
+3. Review the generated release issue content:
+
+```bash
 galaxy-release-util create-release-issue <RELEASE_TAG> --freeze-date 'YEAR-MONTH-DAY' --release-date 'YEAR-MONTH-DAY' --next-version <NEXT_RELEASE_TAG> --dry-run yes
 ```
 
-4. Re-run the above command without the `--dry-run` argument to actually open a release publication issue on `GitHub`.
+4. Re run the command without `--dry-run` to open the issue on GitHub.
 
-### Step 7: Create Milestone for Future Release
-Using the GitHub interface, create a new milestone.
+---
 
-1. Go to https://github.com/galaxyproject/galaxy/milestones
-  
-2. Click **New milestone** and create a new milestone
+### Step 7: Create Milestone for Next Release
 
-3. Note the milestone number from the URL:  
+Create a milestone for the next release so new pull requests are tagged correctly.
+
+1. Go to [https://github.com/galaxyproject/galaxy/milestones](https://github.com/galaxyproject/galaxy/milestones)
+
+2. Click New milestone and create a milestone for <NEXT_RELEASE_TAG>
+
+3. Note the milestone number from the URL:
+
 ```
 https://github.com/galaxyproject/galaxy/milestone/<MILESTONE_NUMBER>
 ```
 
-5. Edit https://github.com/galaxyproject/galaxy/blob/dev/.github/workflows/maintenance_bot.yaml and update `<MILESTONE_NUMBER>` so new pull requests are tagged with the correct milestone
+4. Edit [https://github.com/galaxyproject/galaxy/blob/dev/.github/workflows/maintenance_bot.yaml](https://github.com/galaxyproject/galaxy/blob/dev/.github/workflows/maintenance_bot.yaml) and update `<MILESTONE_NUMBER>` so new pull requests are assigned to the correct milestone
 
-6. Open a pull request to update the milestone.  
-   Example: https://github.com/galaxyproject/galaxy/pull/20946
+5. Open a pull request to apply the change
 
-### Step 8: Are we good to freeze?
+---
 
-Use the following filter to identify PRs without `kind/*` labels and assign the appropriate `kind/*` labels. This helps compile the final list of PRs for the current milestone that must be included in the release by the freeze date.
+### Step 8: Freeze Meeting
 
-1. Go to: https://github.com/galaxyproject/galaxy/pulls and search for:
+One week before the freeze, hold the Freeze Meeting, usually during a weekly dev meeting. In this meeting, review open pull requests, decide what will be included in the <RELEASE_TAG> release, and assign reviewers to ensure merges complete before the freeze. Milestone decisions made here are binding for the freeze.
+
+To list pull requests for discussion:
+
+1. Go to [https://github.com/galaxyproject/galaxy/pulls](https://github.com/galaxyproject/galaxy/pulls) and search for:
+
+```
+is:open is:pr milestone:<RELEASE_TAG> -label:kind/bug -is:draft
+```
+
+---
+
+### Step 9: Final Pre Freeze Milestone and Label Audit
+
+Before freezing, ensure all pull requests in the milestone have appropriate `kind/*` labels and correct milestone assignment.
+
+1. Go to [https://github.com/galaxyproject/galaxy/pulls](https://github.com/galaxyproject/galaxy/pulls) and search for:
+
 ```
 is:open is:pr milestone:<RELEASE_TAG> -label:"kind/feature" -label:"kind/bug" -label:"kind/enhancement" -label:"kind/refactoring" -label:dependencies
 ```
 
-2. Assign proper labels, and milestones to these PRs
+2. Assign appropriate labels and milestones to these pull requests
 
-### Step 9: Review of Blockers
+---
 
-Write the following message to above channels:
+### Step 10: Confirm and Announce Freeze
 
-> 📌 We're Frozen!
-> Hey everyone!
-> As planned, as of today we're officially frozen for <RELEASE_TAG> - no new features or enhancements against the <RELEASE_TAG> milestone after this point.
-> We still have <NUMBER_OF_OPEN_PRS> PRs from the freeze list that need to be merged before we can branch. It would be great if folks can review these remaining ones as soon as possible, so we can actually branch. Even if a PR is assigned to someone else, feel free to jump in with a review!
-> Link to the remaining PRs: https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+-label%3A%22kind%2Fbug%22+-is%3Adraft+milestone%3A<RELEASE_TAG>
+After completing the audit, the release manager confirms the freeze and announces it.
 
-### Step 10: Review Merged PRs
+Send the following message:
 
-1. Go to: https://github.com/galaxyproject/galaxy/pulls
+> 📌 We are now frozen for <RELEASE_TAG>
+>
+> As of today, we are officially frozen for <RELEASE_TAG>. No new features or enhancements should be added to the <RELEASE_TAG> milestone after this point.
+> We still have <NUMBER_OF_OPEN_PRS> pull requests from the freeze list that must be merged before we can branch. Reviews are appreciated so we can proceed with branching.
+> Remaining PRs: [https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+-label%3A%22kind%2Fbug%22+-is%3Adraft+milestone%3A](https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+-label%3A%22kind%2Fbug%22+-is%3Adraft+milestone%3A)<RELEASE_TAG>
 
-2. Identify all PRs merged since the last release that are missing the appropriate tag and assign the correct tag. Search for:
+---
+
+### Step 11: Review Merged Pull Requests
+
+Ensure all merged pull requests for the release are correctly labeled and titled to support accurate release notes.
+
+1. Identify merged pull requests missing a milestone:
+
 ```
 is:pr is:merged -label:merge sort:merged merged:><YEAR-MONTH-DAY-PREVIOUS-RELEASE> -milestone:<RELEASE_TAG>
 ```
 
-4. Review all PRs for the new release and update their titles as needed according to the Galaxy contributing guidelines, particularly point 6: https://github.com/galaxyproject/galaxy/blob/dev/CONTRIBUTING.md#how-to-contribute. Search for:
-```
-is:pr milestone:<RELEASE_TAG>
-```
+2. Assign the correct milestone to these pull requests
 
-### Step 11: Update Database Revision
+3. Review titles of all pull requests in the milestone and adjust them conservatively to match Galaxy contribution guidelines
 
-1. Switch to your `dev` branch and ensure it is up to date, for example by running:  
+---
+
+### Step 12: Update Database Revision
+
+Update the database revision mapping for the release. This change must land before branching.
+
+1. Ensure `dev` is up to date:
+
 ```bash
 git pull upstream dev
 ```
 
-2. Run:  
+2. Run:
+
 ```bash
 ./manage_db.sh version
 ```
 
-3. Note the first revision identifier `<DB_REVISION> (gxy) (head)`.
+3. Note the revision identifier marked as head
 
-4. Edit `lib/galaxy/model/migrations/dbrevisions.py` and add a new entry:  
+4. Add the mapping to `lib/galaxy/model/migrations/dbrevisions.py`:
+
 ```
 "<RELEASE_TAG>": "<DB_REVISION>",
 ```
 
-6. Open a pull request to update the database revision.  
-   Example: https://github.com/galaxyproject/galaxy/pull/21017
+5. Open and merge a pull request with this change
 
-### Step 12: Merge Previous Release into `dev`
+---
 
-1. Check out the previous release:  
+### Step 13: Merge Previous Release into dev
+
+Merge the previous release branch into `dev` to ensure all backported fixes are present.
+
+1. Check out and update the previous release:
+
 ```bash
 git checkout release_<PREVIOUS_RELEASE_TAG>
-```
-
-2. Ensure the previous release is up to date:  
-```bash
 git pull upstream release_<PREVIOUS_RELEASE_TAG>
 ```
 
-3. Check out `dev` and merge the previous release into it:  
+2. Merge into dev:
+
 ```bash
 git checkout dev
 git merge release_<PREVIOUS_RELEASE_TAG>
@@ -187,36 +261,64 @@ git commit -a -m "Merge <PREVIOUS_RELEASE_TAG> into dev"
 git push
 ```
 
-6. Open a pull request against `dev` and merge it.
+3. Open and merge the resulting pull request
 
-### Step 13: Create Release Candidate Branches
+---
 
-1. Check out the `dev` branch and pull the latest changes:  
+### Step 14: Create Release Candidate Branches
+
+Create release candidate and next dev version branches.
+
+1. Update dev:
+
 ```bash
 git checkout dev
 git pull upstream dev
 ```
 
-2. Run the release creation command:  
+2. Run:
+
 ```bash
+source .venv/bin/activate
 make release-create-rc
 ```
 
-3. This command creates two branches:
+This creates two branches:
 
-   **a. `version-<FUTURE_RELEASE_TAG>.dev`**  
-   Title: `Version <FUTURE_RELEASE_TAG>.dev`  
-   - Open a pull request **against `dev`**.  
-     Example: [https://github.com/galaxyproject/galaxy/pull/21020](https://github.com/galaxyproject/galaxy/pull/21020)  
-   - **Note:** Manually verify this step because it:  
-     1. may generate the wrong future release number  
-     2. adds a client-hash-build file that must be removed
+a. `version-<NEXT_RELEASE_TAG>.dev`
 
-   **b. `version-<RELEASE_TAG>.rc1`**  
-   Title: `Update version to <RELEASE_TAG>.rc1`  
-   - Open a pull request **against `galaxyproject:release_<RELEASE_TAG>`**.  
-     Example: [https://github.com/galaxyproject/galaxy/pull/21019](https://github.com/galaxyproject/galaxy/pull/21019)
+* Title: Version <NEXT_RELEASE_TAG>.dev
+* Open a pull request against `dev`
+* Verify the future version number and remove any generated client hash build artifacts if present
 
+b. `version-<RELEASE_TAG>.rc1`
 
-   
-   
+* Title: Update version to <RELEASE_TAG>.rc1
+* Open a pull request against galaxyproject:release_<RELEASE_TAG>.
+*  Example: https://github.com/galaxyproject/galaxy/pull/21019
+
+Note: These steps may silently fail without producing any branches. Inspect `cat packages/app/make-dist.log` if branches were not created.
+
+---
+
+### Step 15: Create a new GitHub label
+
+* Navigate to https://github.com/galaxyproject/galaxy/issues
+* Click on `Labels` and `New label`
+* Create a new label: `release-testing-<RELEASE_TAG>`
+* Use this label to tag all release testing PRs
+
+---
+
+### Step 16: Announce Branching
+
+Send the following message:
+
+> 🌱 Branched <RELEASE_TAG>
+>
+> The <RELEASE_TAG> release branch has been created.
+
+Send this message to at least the following channels:
+
+* [https://matrix.to/#/#galaxyproject_ui-ux:gitter.im](https://matrix.to/#/#galaxyproject_ui-ux:gitter.im)
+* [https://matrix.to/#/#galaxyproject_backend:gitter.im](https://matrix.to/#/#galaxyproject_backend:gitter.im)

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,6 @@
 # Galaxy Release Manager Tasks
 
-This document provides a step by step guide for managing Galaxy releases. It outlines the responsibilities of the release manager from determining the freeze date to preparing and executing the release. Each step includes concrete actions, commands, and communication guidance to ensure a predictable and coordinated release process.
+This document provides a step by step guide for preparing a Galaxy release. It covers all steps up to and including the creation of the release publication issue. Once the issue is created, all subsequent steps are tracked as checkboxes in the issue itself, making it the single source of truth for the release process.
 
 ## Terminology
 
@@ -24,7 +24,7 @@ Two weeks before the planned freeze, announce the Freeze Meeting for the followi
 
 Send the following message:
 
-> 🗓️ Freeze Meeting on <FREEZE_MEETING_DATE>
+> Freeze Meeting on <FREEZE_MEETING_DATE>
 >
 > We will meet on <FREEZE_MEETING_DATE> for the Freeze Meeting, one week before the actual freeze. We will review open PRs, decide what will be included in the <RELEASE_TAG> release, and assign reviewers to ensure merges are completed by the freeze date. If you have outstanding PRs, please make sure they are set to ready for review before the meeting.
 
@@ -142,7 +142,7 @@ All fields are required. Two optional fields, `owner` and `repo`, default to `"g
 
 ### Step 7: Open New Release Publication Issue
 
-Using `galaxy-release-util`, create the release publication issue that tracks all publication tasks for the current release.
+Using `galaxy-release-util`, create the release publication issue that tracks all remaining release tasks.
 
 1. Ensure you are in the `galaxy-release-util` virtual environment.
 
@@ -162,223 +162,4 @@ To use a config file at a non-default location, add `--release-config /path/to/c
 
 4. Re run the command without `--dry-run` to open the issue on GitHub.
 
----
-
-### Step 8: Create Milestone for Next Release
-
-Create a milestone for the next release so new pull requests are tagged correctly.
-
-1. Go to [https://github.com/galaxyproject/galaxy/milestones](https://github.com/galaxyproject/galaxy/milestones)
-
-2. Click New milestone and create a milestone for <NEXT_RELEASE_TAG>
-
-3. Note the milestone number from the URL:
-
-```
-https://github.com/galaxyproject/galaxy/milestone/<MILESTONE_NUMBER>
-```
-
-4. Edit [https://github.com/galaxyproject/galaxy/blob/dev/.github/workflows/maintenance_bot.yaml](https://github.com/galaxyproject/galaxy/blob/dev/.github/workflows/maintenance_bot.yaml) and update `<MILESTONE_NUMBER>` so new pull requests are assigned to the correct milestone
-
-5. Open a pull request to apply the change
-
----
-
-### Step 9: Freeze Meeting
-
-One week before the freeze, hold the Freeze Meeting, usually during a weekly dev meeting. In this meeting, review open pull requests, decide what will be included in the <RELEASE_TAG> release, and assign reviewers to ensure merges complete before the freeze. Milestone decisions made here are binding for the freeze.
-
-To list pull requests for discussion:
-
-1. Go to [https://github.com/galaxyproject/galaxy/pulls](https://github.com/galaxyproject/galaxy/pulls) and search for:
-
-```
-is:open is:pr milestone:<RELEASE_TAG> -label:kind/bug -is:draft
-```
-
----
-
-### Step 10: Final Pre Freeze Milestone and Label Audit
-
-Before freezing, ensure all pull requests in the milestone have appropriate `kind/*` labels and correct milestone assignment.
-
-1. Go to [https://github.com/galaxyproject/galaxy/pulls](https://github.com/galaxyproject/galaxy/pulls) and search for:
-
-```
-is:open is:pr milestone:<RELEASE_TAG> -label:"kind/feature" -label:"kind/bug" -label:"kind/enhancement" -label:"kind/refactoring" -label:dependencies
-```
-
-2. Assign appropriate labels and milestones to these pull requests
-
----
-
-### Step 11: Confirm and Announce Freeze
-
-After completing the audit, the release manager confirms the freeze and announces it.
-
-Send the following message:
-
-> 📌 We are now frozen for <RELEASE_TAG>
->
-> As of today, we are officially frozen for <RELEASE_TAG>. No new features or enhancements should be added to the <RELEASE_TAG> milestone after this point.
-> We still have <NUMBER_OF_OPEN_PRS> pull requests from the freeze list that must be merged before we can branch. Reviews are appreciated so we can proceed with branching.
-> Remaining PRs: https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+-label%3A%22kind%2Fbug%22+-is%3Adraft+milestone%3A<RELEASE_TAG>
-
----
-
-### Step 12: Review Merged Pull Requests
-
-Ensure all merged pull requests for the release are correctly labeled and titled to support accurate release notes.
-
-1. Identify merged pull requests missing a milestone:
-
-```
-is:pr is:merged -label:merge sort:merged merged:><YEAR-MONTH-DAY-PREVIOUS-RELEASE> -milestone:<RELEASE_TAG>
-```
-
-2. Assign the correct milestone to these pull requests
-
-3. Review titles of all pull requests in the milestone and adjust them conservatively to match Galaxy contribution guidelines
-
----
-
-### Step 13: Update Database Revision
-
-Update the database revision mapping for the release. This change must land before branching.
-
-1. Ensure `dev` is up to date:
-
-```bash
-git pull upstream dev
-```
-
-2. Run:
-
-```bash
-./manage_db.sh version
-```
-
-3. Note the revision identifier marked as head
-
-4. Add the mapping to `lib/galaxy/model/migrations/dbrevisions.py`:
-
-```
-"<RELEASE_TAG>": "<DB_REVISION>",
-```
-
-5. Open and merge a pull request with this change
-
----
-
-### Step 14: Merge Previous Release into dev
-
-Merge the previous release branch into `dev` to ensure all backported fixes are present.
-
-1. Check out and update the previous release:
-
-```bash
-git checkout release_<PREVIOUS_RELEASE_TAG>
-git pull upstream release_<PREVIOUS_RELEASE_TAG>
-```
-
-2. Merge into dev:
-
-```bash
-git checkout dev
-git merge release_<PREVIOUS_RELEASE_TAG>
-git commit -a -m "Merge <PREVIOUS_RELEASE_TAG> into dev"
-git push
-```
-
-3. Open and merge the resulting pull request
-
----
-
-### Step 15: Create Release Candidate Branches
-
-Create release candidate and next dev version branches.
-
-1. Update dev:
-
-```bash
-git checkout dev
-git pull upstream dev
-```
-
-2. Run:
-
-```bash
-source .venv/bin/activate
-make release-create-rc
-```
-
-This creates two branches:
-
-a. `version-<NEXT_RELEASE_TAG>.dev`
-
-* Title: Version <NEXT_RELEASE_TAG>.dev
-* Open a pull request against `dev`
-* Verify the future version number and remove any generated client hash build artifacts if present
-
-b. `version-<RELEASE_TAG>.rc1`
-
-* Title: Update version to <RELEASE_TAG>.rc1
-* Open a pull request against galaxyproject:release_<RELEASE_TAG>.
-* Example: https://github.com/galaxyproject/galaxy/pull/21019
-
-Note: These steps may silently fail without producing any branches. Inspect `cat packages/app/make-dist.log` if branches were not created.
-
----
-
-### Step 16: Create a new GitHub label
-
-* Navigate to https://github.com/galaxyproject/galaxy/issues
-* Click on `Labels` and `New label`
-* Create a new label: `release-testing-<RELEASE_TAG>`
-* Use this label to tag all release testing PRs
-
----
-
-### Step 17: Announce Branching
-
-Send the following message:
-
-> 🌱 Branched <RELEASE_TAG>
->
-> The <RELEASE_TAG> release branch has been created.
-
-Send this message to at least the following channels:
-
-* [https://matrix.to/#/#galaxyproject_ui-ux:gitter.im](https://matrix.to/#/#galaxyproject_ui-ux:gitter.im)
-* [https://matrix.to/#/#galaxyproject_backend:gitter.im](https://matrix.to/#/#galaxyproject_backend:gitter.im)
-
----
-
-### Step 18: Assemble Testing Team
-
-Reach out per email to assemble the testing team for the upcoming release:
-
->**Galaxy <RELEASE_TAG> Release Testing**
->
->Hi,
->
->I am organizing testing for the upcoming Galaxy release and would like to ask whether you would be available to participate.
->
->**Testing window:**
->**<DAY_NAME> <MONTH_NAME> <DAY_COUNT>** through **<DAY_NAME> <MONTH_NAME> <DAY_COUNT>**
->
->**Time commitment:**
->Approximately 1-2 hours per day. Testing consists of working through as many assigned PRs as time permits. There will be one short kick off meeting immediately before testing begins.
->
->**What release testing involves:**
->Release testing focuses on validating Galaxy GitHub pull requests. Each PR represents either a new feature, an enhancement, or a bug fix. Testing means exercising the changes as a user would and verifying that they behave correctly and do not introduce regressions. A curated list of PRs will be provided, and detailed guidance on the testing workflow and PR selection will be covered in the kick off meeting.
->
->I will be available throughout the testing period, and the galaxyproject/release-testing channel on Element will be used for coordination and questions.
->
->If you are able to participate, I will follow up with concrete details.
->
->Thanks!
-
----
-
-### Step 19: Continue with Release Issue
+All subsequent release steps are tracked as checkboxes in the publication issue.

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -352,8 +352,6 @@ def create_release_issue(
         previous_version, next_version, release_date, freeze_date,
     )
     assert config.next_version > config.current_version, "Next release version should be greater than current version"
-    if config.freeze_date is None:
-        raise click.UsageError("freeze-date is required for create-release-issue (set it in the config YAML or pass --freeze-date)")
 
     issue_template_params = dict(
         version=release_version,

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -255,7 +255,7 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
           git checkout release_${version} -b ${version}_release_notes
     - [ ] Bootstrap the release notes
 
-          galaxy-release-util create-changelog ${version} --galaxy-root .
+          galaxy-release-util create-changelog ${version} --galaxy-root . --next-version ${next_version}
     - [ ] Open newly created files and manually curate major topics and release notes.
     - [ ] Run ``python scripts/release-diff.py release_${previous_version}`` and add configuration changes to release notes.
     - [ ] Add new release to doc/source/releases/index.rst
@@ -283,7 +283,7 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
     - [ ] Ensure all pull requests merged into the pre-release branch during the freeze are the not [${next_version} milestones](https://github.com/galaxyproject/galaxy/pulls?q=is%3Apr+is%3Aclosed+base%3Arelease_${version}+is%3Amerged+milestone%3A${next_version})
     - [ ] Ensure release notes include all pull requests added during the freeze by re-running the release note bootstrapping:
 
-          galaxy-release-util create-changelog ${version} --galaxy-root .
+          galaxy-release-util create-changelog ${version} --galaxy-root . --next-version ${next_version}
     - [ ] Ensure previous release is merged into current. [GitHub branch comparison](https://github.com/galaxyproject/galaxy/compare/release_${version}...release_${previous_version})
     - [ ] Create the first point release (v${version}.0) using the instructions at https://docs.galaxyproject.org/en/master/dev/create_release.html#creating-galaxy-point-releases
 

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -21,9 +21,13 @@ from packaging.version import Version
 
 from .cli.options import (
     ClickVersion,
+    freeze_date_option,
     galaxy_root_option,
     group_options,
+    next_version_option,
+    previous_version_option,
     release_config_option,
+    release_date_option,
 )
 from .github_client import github_client
 from .metadata import (
@@ -326,16 +330,27 @@ def cli():
     release_version_argument,
     galaxy_root_option,
     release_config_option,
+    previous_version_option,
+    next_version_option,
+    release_date_option,
+    freeze_date_option,
     dry_run_option,
 )
 def create_release_issue(
     release_version: Version,
     galaxy_root: Path,
     release_config: Optional[Path],
+    previous_version: Optional[Version],
+    next_version: Optional[Version],
+    release_date: Optional[datetime.date],
+    freeze_date: Optional[datetime.date],
     dry_run: bool,
 ):
     verify_galaxy_root(galaxy_root)
-    config = load_release_config(galaxy_root, release_version, release_config)
+    config = load_release_config(
+        galaxy_root, release_version, release_config,
+        previous_version, next_version, release_date, freeze_date,
+    )
     assert config.next_version > release_version, "Next release version should be greater than release version"
 
     issue_template_params = dict(
@@ -368,10 +383,31 @@ def create_release_issue(
 
 
 @cli.command(help="Create or update release changelog")
-@group_options(release_version_argument, galaxy_root_option, release_config_option, dry_run_option)
-def create_changelog(release_version: Version, galaxy_root: Path, release_config: Optional[Path], dry_run: bool):
+@group_options(
+    release_version_argument,
+    galaxy_root_option,
+    release_config_option,
+    previous_version_option,
+    next_version_option,
+    release_date_option,
+    freeze_date_option,
+    dry_run_option,
+)
+def create_changelog(
+    release_version: Version,
+    galaxy_root: Path,
+    release_config: Optional[Path],
+    previous_version: Optional[Version],
+    next_version: Optional[Version],
+    release_date: Optional[datetime.date],
+    freeze_date: Optional[datetime.date],
+    dry_run: bool,
+):
     verify_galaxy_root(galaxy_root)
-    config = load_release_config(galaxy_root, release_version, release_config)
+    config = load_release_config(
+        galaxy_root, release_version, release_config,
+        previous_version, next_version, release_date, freeze_date,
+    )
     release_date = config.release_date
     next_version = config.next_version
 
@@ -408,10 +444,31 @@ def create_changelog(release_version: Version, galaxy_root: Path, release_config
 
 
 @cli.command(help="List release blocking PRs")
-@group_options(release_version_argument, galaxy_root_option, release_config_option, dry_run_option)
-def check_blocking_prs(release_version: Version, galaxy_root: Path, release_config: Optional[Path], dry_run: bool):
+@group_options(
+    release_version_argument,
+    galaxy_root_option,
+    release_config_option,
+    previous_version_option,
+    next_version_option,
+    release_date_option,
+    freeze_date_option,
+    dry_run_option,
+)
+def check_blocking_prs(
+    release_version: Version,
+    galaxy_root: Path,
+    release_config: Optional[Path],
+    previous_version: Optional[Version],
+    next_version: Optional[Version],
+    release_date: Optional[datetime.date],
+    freeze_date: Optional[datetime.date],
+    dry_run: bool,
+):
     verify_galaxy_root(galaxy_root)
-    config = load_release_config(galaxy_root, release_version, release_config)
+    config = load_release_config(
+        galaxy_root, release_version, release_config,
+        previous_version, next_version, release_date, freeze_date,
+    )
     if dry_run:
         click.echo(f"Dry run: would check blocking PRs for milestone {release_version}")
         sys.exit(0)
@@ -423,10 +480,31 @@ def check_blocking_prs(release_version: Version, galaxy_root: Path, release_conf
 
 
 @cli.command(help="List release blocking issues")
-@group_options(release_version_argument, galaxy_root_option, release_config_option, dry_run_option)
-def check_blocking_issues(release_version: Version, galaxy_root: Path, release_config: Optional[Path], dry_run: bool):
+@group_options(
+    release_version_argument,
+    galaxy_root_option,
+    release_config_option,
+    previous_version_option,
+    next_version_option,
+    release_date_option,
+    freeze_date_option,
+    dry_run_option,
+)
+def check_blocking_issues(
+    release_version: Version,
+    galaxy_root: Path,
+    release_config: Optional[Path],
+    previous_version: Optional[Version],
+    next_version: Optional[Version],
+    release_date: Optional[datetime.date],
+    freeze_date: Optional[datetime.date],
+    dry_run: bool,
+):
     verify_galaxy_root(galaxy_root)
-    config = load_release_config(galaxy_root, release_version, release_config)
+    config = load_release_config(
+        galaxy_root, release_version, release_config,
+        previous_version, next_version, release_date, freeze_date,
+    )
     if dry_run:
         click.echo(f"Dry run: would check blocking issues for milestone {release_version}")
         sys.exit(0)

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -576,36 +576,6 @@ def _write_file(path: Path, contents: str, skip_if_exists: bool = False) -> None
         f.write(contents)
 
 
-def _get_previous_release_version(galaxy_root: Path, version: Version) -> Optional[Version]:
-    """Return previous release version if it exists."""
-    # NOTE: We convert strings to Version objects to compare apples to apples:
-    # str(Version(foo)) is not the same as the string foo: str(Version("22.05")) == "22.5"
-    prev = None
-    for release in _get_release_version_strings(galaxy_root):
-        release_version = Version(release)
-        if release_version >= version:
-            return prev
-        prev = release_version
-    return prev
-
-
-def _get_release_version_strings(galaxy_root: Path) -> List[str]:
-    """Return sorted list of release version strings."""
-    all_files = _get_release_documentation_filenames(galaxy_root)
-    release_notes_file_pattern = re.compile(r"\d+\.\d+\.rst")
-    filenames = [f[:-4] for f in all_files if release_notes_file_pattern.match(f)]
-    return sorted(filenames)
-
-
-def _get_release_documentation_filenames(galaxy_root: Path) -> List[str]:
-    """Return contents of release documentation directory."""
-    releases_path = galaxy_root / "doc" / "source" / "releases"
-    if not os.path.exists(releases_path):
-        msg = f"Path to releases documentation not found: {releases_path}"
-        raise Exception(msg)
-    return sorted(os.listdir(releases_path))
-
-
 def _release_file(galaxy_root: Path, filename: Optional[str]) -> Path:
     """Construct and return path to a release documentation file."""
     filename = filename or OLDER_RELEASES_FILENAME

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -351,6 +351,8 @@ def create_release_issue(
         galaxy_root, release_version, release_config,
         previous_version, next_version, release_date, freeze_date,
     )
+    if config.next_version is None:
+        raise click.UsageError("--next-version is required for create-release-issue")
     assert config.next_version > config.current_version, "Next release version should be greater than current version"
 
     issue_template_params = dict(
@@ -408,6 +410,8 @@ def create_changelog(
         galaxy_root, release_version, release_config,
         previous_version, next_version, release_date, freeze_date,
     )
+    if config.next_version is None:
+        raise click.UsageError("--next-version is required for create-changelog")
     release_date = config.release_date
     next_version = config.next_version
 
@@ -449,7 +453,6 @@ def create_changelog(
     galaxy_root_option,
     release_config_option,
     previous_version_option,
-    next_version_option,
     release_date_option,
     freeze_date_option,
     dry_run_option,
@@ -459,7 +462,6 @@ def check_blocking_prs(
     galaxy_root: Path,
     release_config: Optional[Path],
     previous_version: Optional[Version],
-    next_version: Optional[Version],
     release_date: Optional[datetime.date],
     freeze_date: Optional[datetime.date],
     dry_run: bool,
@@ -467,7 +469,7 @@ def check_blocking_prs(
     verify_galaxy_root(galaxy_root)
     config = load_release_config(
         galaxy_root, release_version, release_config,
-        previous_version, next_version, release_date, freeze_date,
+        previous_version, None, release_date, freeze_date,
     )
     if dry_run:
         click.echo(f"Dry run: would check blocking PRs for milestone {release_version}")
@@ -485,7 +487,6 @@ def check_blocking_prs(
     galaxy_root_option,
     release_config_option,
     previous_version_option,
-    next_version_option,
     release_date_option,
     freeze_date_option,
     dry_run_option,
@@ -495,7 +496,6 @@ def check_blocking_issues(
     galaxy_root: Path,
     release_config: Optional[Path],
     previous_version: Optional[Version],
-    next_version: Optional[Version],
     release_date: Optional[datetime.date],
     freeze_date: Optional[datetime.date],
     dry_run: bool,
@@ -503,7 +503,7 @@ def check_blocking_issues(
     verify_galaxy_root(galaxy_root)
     config = load_release_config(
         galaxy_root, release_version, release_config,
-        previous_version, next_version, release_date, freeze_date,
+        previous_version, None, release_date, freeze_date,
     )
     if dry_run:
         click.echo(f"Dry run: would check blocking issues for milestone {release_version}")

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -351,7 +351,7 @@ def create_release_issue(
         galaxy_root, release_version, release_config,
         previous_version, next_version, release_date, freeze_date,
     )
-    assert config.next_version > release_version, "Next release version should be greater than release version"
+    assert config.next_version > config.current_version, "Next release version should be greater than current version"
 
     issue_template_params = dict(
         version=release_version,

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -352,6 +352,8 @@ def create_release_issue(
         previous_version, next_version, release_date, freeze_date,
     )
     assert config.next_version > config.current_version, "Next release version should be greater than current version"
+    if config.freeze_date is None:
+        raise click.UsageError("freeze-date is required for create-release-issue (set it in the config YAML or pass --freeze-date)")
 
     issue_template_params = dict(
         version=release_version,

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -684,6 +684,4 @@ def wrap(message: str, owner: str = PROJECT_OWNER, repo: str = PROJECT_NAME) -> 
 
 
 def _issue_to_str(issue: Issue) -> str:
-    if isinstance(issue, str):
-        return issue
     return f"Issue #{issue.number} ({issue.title}) {issue.html_url}"

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -251,7 +251,7 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
           git checkout release_${version} -b ${version}_release_notes
     - [ ] Bootstrap the release notes
 
-          galaxy-release-util create-changelog ${version} --release-date ${release_date} --next-version ${next_version}
+          galaxy-release-util create-changelog ${version} --galaxy-root .
     - [ ] Open newly created files and manually curate major topics and release notes.
     - [ ] Run ``python scripts/release-diff.py release_${previous_version}`` and add configuration changes to release notes.
     - [ ] Add new release to doc/source/releases/index.rst
@@ -271,15 +271,15 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
 
     - [ ] Ensure all [blocking milestone issues](https://github.com/galaxyproject/galaxy/issues?q=is%3Aopen+is%3Aissue+milestone%3A${version}) have been resolved.
 
-          galaxy-release-util check-blocking-issues ${version}
+          galaxy-release-util check-blocking-issues ${version} --galaxy-root .
     - [ ] Ensure all [blocking milestone pull requests](https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+milestone%3A${version}) have been merged, closed, or postponed until the next release.
 
-          galaxy-release-util check-blocking-prs ${version} --release-date ${release_date}
+          galaxy-release-util check-blocking-prs ${version} --galaxy-root .
     - [ ] Ensure all pull requests merged into the pre-release branch during the freeze have [milestones attached](https://github.com/galaxyproject/galaxy/pulls?q=is%3Apr+is%3Aclosed+base%3Arelease_${version}+is%3Amerged+no%3Amilestone)
     - [ ] Ensure all pull requests merged into the pre-release branch during the freeze are the not [${next_version} milestones](https://github.com/galaxyproject/galaxy/pulls?q=is%3Apr+is%3Aclosed+base%3Arelease_${version}+is%3Amerged+milestone%3A${next_version})
     - [ ] Ensure release notes include all pull requests added during the freeze by re-running the release note bootstrapping:
 
-          galaxy-release-util create-changelog ${version} --release-date ${release_date} --next-version ${next_version}
+          galaxy-release-util create-changelog ${version} --galaxy-root .
     - [ ] Ensure previous release is merged into current. [GitHub branch comparison](https://github.com/galaxyproject/galaxy/compare/release_${version}...release_${previous_version})
     - [ ] Create the first point release (v${version}.0) using the instructions at https://docs.galaxyproject.org/en/master/dev/create_release.html#creating-galaxy-point-releases
 
@@ -410,6 +410,7 @@ def create_changelog(release_version: Version, galaxy_root: Path, release_config
 @cli.command(help="List release blocking PRs")
 @group_options(release_version_argument, galaxy_root_option, release_config_option, dry_run_option)
 def check_blocking_prs(release_version: Version, galaxy_root: Path, release_config: Optional[Path], dry_run: bool):
+    verify_galaxy_root(galaxy_root)
     config = load_release_config(galaxy_root, release_version, release_config)
     if dry_run:
         click.echo(f"Dry run: would check blocking PRs for milestone {release_version}")
@@ -424,6 +425,7 @@ def check_blocking_prs(release_version: Version, galaxy_root: Path, release_conf
 @cli.command(help="List release blocking issues")
 @group_options(release_version_argument, galaxy_root_option, release_config_option, dry_run_option)
 def check_blocking_issues(release_version: Version, galaxy_root: Path, release_config: Optional[Path], dry_run: bool):
+    verify_galaxy_root(galaxy_root)
     config = load_release_config(galaxy_root, release_version, release_config)
     if dry_run:
         click.echo(f"Dry run: would check blocking issues for milestone {release_version}")

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -40,7 +40,10 @@ from .metadata import (
     strip_release,
 )
 from .release_config import load_release_config
-from .util import verify_galaxy_root
+from .util import (
+    escape_rst_inline,
+    verify_galaxy_root,
+)
 
 OLDER_RELEASES_FILENAME = "older_releases.rst"
 
@@ -632,7 +635,7 @@ def _pr_to_doc(
         _write_file(filename, content)
 
     def make_pr_to_doc() -> str:
-        to_doc = pr.title.rstrip(".") + " "
+        to_doc = escape_rst_inline(pr.title).rstrip(".") + " "
         to_doc += f"\n(thanks to `@{pr.user.login} <https://github.com/{pr.user.login}>`__)."
         to_doc += f"\n`Pull Request {pr.number}`_"
         return wrap(to_doc, owner, repo)

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -195,13 +195,32 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
 - [ ] **Freeze Release (on or around ${freeze_date})**
 
     - [ ] Verify that your installed version of `galaxy-release-util` is up-to-date.
-    - [ ] [Create milestone](https://github.com/galaxyproject/galaxy/milestones) `${next_version}` for next release.
-    - [ ] Update ``MILESTONE_NUMBER`` in the [maintenance bot](https://github.com/galaxyproject/galaxy/blob/dev/.github/workflows/maintenance_bot.yaml) to reference `${next_version}` so it properly tags new pull requests.
+    - [ ] [Create milestone](https://github.com/galaxyproject/galaxy/milestones) `${next_version}` for next release. Note the milestone number from the URL (`https://github.com/galaxyproject/galaxy/milestone/<NUMBER>`).
+    - [ ] Update ``MILESTONE_NUMBER`` in the [maintenance bot](https://github.com/galaxyproject/galaxy/blob/dev/.github/workflows/maintenance_bot.yaml) to reference `${next_version}` so it properly tags new pull requests. Open a pull request to apply the change.
+    - [ ] Hold the Freeze Meeting (one week before freeze, usually during a weekly dev meeting). Review [open milestone pull requests](https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+milestone%3A${version}+-label%3Akind%2Fbug+-is%3Adraft), decide what will be included in `${version}`, and assign reviewers to ensure merges complete before the freeze.
+    - [ ] Audit milestone labels. Ensure all open pull requests in the milestone have appropriate `kind/*` labels and correct milestone assignment. [Find unlabeled PRs](https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+milestone%3A${version}+-label%3A%22kind%2Ffeature%22+-label%3A%22kind%2Fbug%22+-label%3A%22kind%2Fenhancement%22+-label%3A%22kind%2Frefactoring%22+-label%3Adependencies).
     - [ ] Ensure all [freeze blocking milestone pull requests](https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+milestone%3A${version}+-label%3A"kind%2Fbug"+-is%3Adraft) have been merged, closed, or postponed until the next release.
+    - [ ] Announce the freeze on the following channels:
+        - [ ] https://matrix.to/#/#galaxyproject_ui-ux:gitter.im
+        - [ ] https://matrix.to/#/#galaxyproject_backend:gitter.im
+
+      Use the following message:
+
+      > As of today, we are officially frozen for ${version}. No new features or enhancements should be added to the ${version} milestone after this point. Reviews are appreciated so we can proceed with branching. Remaining PRs: https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+-label%3A%22kind%2Fbug%22+-is%3Adraft+milestone%3A${version}
+
+- [ ] **Review Merged Pull Requests**
+
+    - [ ] Identify merged pull requests [missing a milestone](https://github.com/galaxyproject/galaxy/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+no%3Amilestone+-label%3Amerge+sort%3Amerged+) merged since `release_${previous_version}` and assign the correct milestone.
+    - [ ] Review titles of all pull requests in the `${version}` milestone. Adjust them conservatively to match Galaxy contribution guidelines.
 
 - [ ] **Branch Release**
 
-    - [ ] Add latest database revision identifier (for ``release_${version}`` and ``${version}``) to ``REVISION_TAGS`` in ``lib/galaxy/model/migrations/dbrevisions.py``.
+    - [ ] Add latest database revision identifier to ``REVISION_TAGS`` in ``lib/galaxy/model/migrations/dbrevisions.py``. To obtain the identifier, ensure `dev` is up to date and run:
+
+          git pull upstream dev
+          ./manage_db.sh version
+
+      Note the revision identifier marked as head. Add the mapping for ``${version}`` and open a pull request.
 
     - [ ] Merge the latest release into dev and push upstream.
 
@@ -212,7 +231,47 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
 
           make release-create-rc
 
-    - [ ] Open pull requests from your fork of branch ``version-${version}.rc1`` to upstream ``release_${version}`` and of ``version-${next_version}.dev`` to ``dev``.
+      This creates two branches:
+
+        - ``version-${next_version}.dev``: Open a pull request against `dev`. Verify the future version number and remove any generated client hash build artifacts if present.
+        - ``version-${version}.rc1``: Open a pull request against `release_${version}`.
+
+      Note: These steps may silently fail without producing any branches. Inspect ``cat packages/app/make-dist.log`` if branches were not created.
+
+    - [ ] Create a new GitHub label `release-testing-${version}` at https://github.com/galaxyproject/galaxy/labels to tag all release testing PRs.
+
+    - [ ] Announce branching on the following channels:
+        - [ ] https://matrix.to/#/#galaxyproject_ui-ux:gitter.im
+        - [ ] https://matrix.to/#/#galaxyproject_backend:gitter.im
+
+      Use the following message:
+
+      > The ${version} release branch has been created.
+
+- [ ] **Assemble Testing Team**
+
+    - [ ] Reach out per email to assemble the testing team for `${version}`. Use the following template:
+
+      > **Galaxy ${version} Release Testing**
+      >
+      > Hi,
+      >
+      > I am organizing testing for the upcoming Galaxy release and would like to ask whether you would be available to participate.
+      >
+      > **Testing window:**
+      > <START_DATE> through <END_DATE>
+      >
+      > **Time commitment:**
+      > Approximately 1-2 hours per day. Testing consists of working through as many assigned PRs as time permits. There will be one short kick off meeting immediately before testing begins.
+      >
+      > **What release testing involves:**
+      > Release testing focuses on validating Galaxy GitHub pull requests. Each PR represents either a new feature, an enhancement, or a bug fix. Testing means exercising the changes as a user would and verifying that they behave correctly and do not introduce regressions. A curated list of PRs will be provided, and detailed guidance on the testing workflow and PR selection will be covered in the kick off meeting.
+      >
+      > I will be available throughout the testing period, and the galaxyproject/release-testing channel on Element will be used for coordination and questions.
+      >
+      > If you are able to participate, I will follow up with concrete details.
+      >
+      > Thanks!
 
 - [ ] **Run tool and workflow tests:**
 

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -266,6 +266,8 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
     - [ ] Update usegalaxy.org to ensure it is running the ``release_${version}`` branch.
     - [ ] Request that toolshed.g2.bx.psu.edu is updated to ``${version}``.
     - [ ] Conduct second stage of release testing on usegalaxy.org.
+        - [ ] Verify weekly, ideally before or during a developer's meeting, by checking the Slack admin channel and asking for any new release related issues.
+        - [ ] Verify that there have not been any new release related issues in sentry.galaxyproject.org.
     - [ ] [Update BioBlend CI testing](https://github.com/galaxyproject/bioblend/blob/main/.github/workflows/test.yaml) to include a ``release_${version}`` target: add ``- release_${version}`` to the ``galaxy_version`` list in ``.github/workflows/test.yaml`` .
     - [ ] Update GALAXY_RELEASE in IUC and devteam github workflows
         - [ ] https://github.com/galaxyproject/tools-iuc/blob/master/.github/workflows/

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -1,6 +1,5 @@
 import calendar
 import datetime
-import logging
 import os
 import re
 import string
@@ -381,9 +380,6 @@ dry_run_option = click.option(
     "--dry-run", is_flag=True, default=False, help="Do not connect to GitHub's API, print out output"
 )
 
-log = logging.getLogger(__name__)
-
-
 @click.group(help="Subcommands of this script can perform various tasks around creating Galaxy releases")
 def cli():
     pass
@@ -417,7 +413,8 @@ def create_release_issue(
     )
     if config.next_version is None:
         raise click.UsageError("--next-version is required for create-release-issue")
-    assert config.next_version > config.current_version, "Next release version should be greater than current version"
+    if config.next_version <= config.current_version:
+        raise click.UsageError(f"--next-version ({config.next_version}) must be greater than release version ({config.current_version})")
 
     issue_template_params = dict(
         version=release_version,
@@ -430,8 +427,8 @@ def create_release_issue(
     issue_title = f"Publication of Galaxy Release v {release_version}"
 
     if dry_run:
-        print(issue_title)
-        print(issue_contents)
+        click.echo(issue_title)
+        click.echo(issue_contents)
         return None
     try:
         github = github_client()
@@ -609,7 +606,7 @@ def _load_prs(
     n_prs = len(prs)
     for i, pr in enumerate(prs):
         if pr.number not in seen_prs:
-            print(f"Processing PR {i + 1} of {n_prs}")
+            click.echo(f"Processing PR {i + 1} of {n_prs}")
             _pr_to_doc(
                 galaxy_root=galaxy_root,
                 release_version=release_version,
@@ -618,7 +615,7 @@ def _load_prs(
                 repo=repo,
             )
         else:
-            print(f"Skipping PR {i + 1} of {n_prs} (previously processed)")
+            click.echo(f"Skipping PR {i + 1} of {n_prs} (previously processed)")
 
 
 def _get_prs(
@@ -642,14 +639,14 @@ def _get_prs(
 
     prs: List[PullRequest] = []
     counter = 0
-    print("Collecting relevant pull requests...")
+    click.echo("Collecting relevant pull requests...")
     for pr in repo.get_pulls(state=state, sort="updated", direction="desc"):
         assert pr.updated_at
         if pr.updated_at.replace(tzinfo=None) < cutoff_time:
             break
         counter += 1
         if counter % 100 == 0:
-            print(
+            click.echo(
                 f"Examined {counter} PRs; collected {len(prs)} (currently on #{pr.number} updated on {pr.updated_at.date()})"
             )
         # Select PRs that are merged + have correct milestone + have not been previously collected and added to the prs file
@@ -657,7 +654,7 @@ def _get_prs(
         if proper_state and pr.milestone and pr.milestone.title == str(release_version):
             prs.append(pr)
 
-    print(f"Collected {len(prs)} pull requests")
+    click.echo(f"Collected {len(prs)} pull requests")
     return prs
 
 

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -441,11 +441,11 @@ def create_release_issue(
             body=issue_contents,
         )
         return release_issue
-    except GithubException:
-        log.exception(
-            "Failed to create an issue on GitHub. You need to be authenticated to use GitHub API."
-            "\nSee galaxy_release_util/github_client.py"
-        )
+    except GithubException as e:
+        raise click.ClickException(
+            f"Failed to create release issue on GitHub: {e}. "
+            "Ensure GITHUB_AUTH is set to a valid personal access token."
+        ) from e
 
 
 @cli.command(help="Create or update release changelog")

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -641,7 +641,8 @@ def _get_prs(
     counter = 0
     click.echo("Collecting relevant pull requests...")
     for pr in repo.get_pulls(state=state, sort="updated", direction="desc"):
-        assert pr.updated_at
+        if pr.updated_at is None:
+            continue
         if pr.updated_at.replace(tzinfo=None) < cutoff_time:
             break
         counter += 1

--- a/galaxy_release_util/cli/options.py
+++ b/galaxy_release_util/cli/options.py
@@ -67,7 +67,7 @@ next_version_option = click.option(
     "--next-version",
     type=ClickVersion(),
     default=None,
-    help="Next planned release version. The first release of a year is YY.0; subsequent releases increment the minor version. Overrides config YAML.",
+    help="Next planned release version (required for create-release-issue and create-changelog). The first release of a year is YY.0; subsequent releases increment the minor version.",
 )
 
 release_date_option = click.option(

--- a/galaxy_release_util/cli/options.py
+++ b/galaxy_release_util/cli/options.py
@@ -47,3 +47,11 @@ class ClickDate(click.ParamType):
             return datetime.datetime.strptime(value, "%Y-%m-%d").date()
         except ValueError as e:
             self.fail(f"{value!r} is not a valid date: {str(e)}", param, ctx)
+
+
+release_config_option = click.option(
+    "--release-config",
+    type=click.Path(exists=True, path_type=pathlib.Path),
+    default=None,
+    help="Path to release config YAML. Default: {galaxy-root}/doc/source/releases/release_{version}.yml",
+)

--- a/galaxy_release_util/cli/options.py
+++ b/galaxy_release_util/cli/options.py
@@ -1,4 +1,3 @@
-import datetime
 import pathlib
 from typing import (
     Any,
@@ -37,16 +36,6 @@ class ClickVersion(click.ParamType):
             return Version(value)
         except ValueError as e:
             self.fail(f"{value!r} is not a valid PEP440 version number: {str(e)}", param, ctx)
-
-
-class ClickDate(click.ParamType):
-    name = "date"
-
-    def convert(self, value: Any, param: Optional[Parameter], ctx: Optional[Context]) -> datetime.date:
-        try:
-            return datetime.datetime.strptime(value, "%Y-%m-%d").date()
-        except ValueError as e:
-            self.fail(f"{value!r} is not a valid date: {str(e)}", param, ctx)
 
 
 release_config_option = click.option(

--- a/galaxy_release_util/cli/options.py
+++ b/galaxy_release_util/cli/options.py
@@ -67,7 +67,7 @@ next_version_option = click.option(
     "--next-version",
     type=ClickVersion(),
     default=None,
-    help="Next release version (overrides config YAML).",
+    help="Next planned release version. The first release of a year is YY.0; subsequent releases increment the minor version. Overrides config YAML.",
 )
 
 release_date_option = click.option(

--- a/galaxy_release_util/cli/options.py
+++ b/galaxy_release_util/cli/options.py
@@ -1,3 +1,4 @@
+import datetime
 import pathlib
 from typing import (
     Any,
@@ -38,9 +39,47 @@ class ClickVersion(click.ParamType):
             self.fail(f"{value!r} is not a valid PEP440 version number: {str(e)}", param, ctx)
 
 
+class ClickDate(click.ParamType):
+    name = "date"
+
+    def convert(self, value: Any, param: Optional[Parameter], ctx: Optional[Context]) -> datetime.date:
+        try:
+            return datetime.datetime.strptime(value, "%Y-%m-%d").date()
+        except ValueError as e:
+            self.fail(f"{value!r} is not a valid date: {str(e)}", param, ctx)
+
+
 release_config_option = click.option(
     "--release-config",
     type=click.Path(exists=True, path_type=pathlib.Path),
     default=None,
     help="Path to release config YAML. Default: {galaxy-root}/doc/source/releases/release_{version}.yml",
+)
+
+previous_version_option = click.option(
+    "--previous-version",
+    type=ClickVersion(),
+    default=None,
+    help="Previous release version (overrides config YAML).",
+)
+
+next_version_option = click.option(
+    "--next-version",
+    type=ClickVersion(),
+    default=None,
+    help="Next release version (overrides config YAML).",
+)
+
+release_date_option = click.option(
+    "--release-date",
+    type=ClickDate(),
+    default=None,
+    help="Release date in YYYY-MM-DD format (overrides config YAML).",
+)
+
+freeze_date_option = click.option(
+    "--freeze-date",
+    type=ClickDate(),
+    default=None,
+    help="Freeze date in YYYY-MM-DD format (overrides config YAML).",
 )

--- a/galaxy_release_util/cli/release_util.py
+++ b/galaxy_release_util/cli/release_util.py
@@ -1,9 +1,9 @@
 import click
 
-from ..bootstrap_history import cli as boostrap_cli
+from ..bootstrap_history import cli as bootstrap_cli
 from ..point_release import cli as point_release_cli
 
 cli = click.CommandCollection(
-    sources=[boostrap_cli, point_release_cli],
+    sources=[bootstrap_cli, point_release_cli],
     help="Perform various tasks around creating Galaxy releases and point releases",
 )

--- a/galaxy_release_util/github_client.py
+++ b/galaxy_release_util/github_client.py
@@ -1,7 +1,10 @@
 import json
+import logging
 import os
 
 from github import Github
+
+log = logging.getLogger(__name__)
 
 
 def github_client() -> Github:
@@ -16,10 +19,19 @@ def github_client() -> Github:
     auth = os.environ.get("GITHUB_AUTH")
     if auth is not None:
         return Github(auth)
-    else:
-        github_json_path = os.path.expanduser("~/.github.json")
-        if not os.path.exists(github_json_path):
-            return Github(None)
+    github_json_path = os.path.expanduser("~/.github.json")
+    if not os.path.exists(github_json_path):
+        raise RuntimeError(
+            "GitHub authentication required but not configured. "
+            "Set the GITHUB_AUTH environment variable to a personal access token, "
+            "or create ~/.github.json with a 'login_or_token' key. "
+            "See https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"
+        )
+    try:
         with open(github_json_path) as fh:
             github_json_dict = json.load(fh)
-        return Github(**github_json_dict)
+    except (json.JSONDecodeError, OSError) as e:
+        raise RuntimeError(f"Failed to read GitHub config from {github_json_path}: {e}") from e
+    if not isinstance(github_json_dict, dict):
+        raise RuntimeError(f"Expected a JSON object in {github_json_path}, got {type(github_json_dict).__name__}")
+    return Github(**github_json_dict)

--- a/galaxy_release_util/github_client.py
+++ b/galaxy_release_util/github_client.py
@@ -1,10 +1,7 @@
 import json
-import logging
 import os
 
 from github import Github
-
-log = logging.getLogger(__name__)
 
 
 def github_client() -> Github:

--- a/galaxy_release_util/metadata.py
+++ b/galaxy_release_util/metadata.py
@@ -20,8 +20,6 @@ GROUPED_TAGS = dict(
 
 
 def _pr_to_str(pr):
-    if isinstance(pr, str):
-        return pr
     return f"PR #{pr.number} ({pr.title}) {pr.html_url}"
 
 

--- a/galaxy_release_util/metadata.py
+++ b/galaxy_release_util/metadata.py
@@ -97,5 +97,13 @@ def _pr_to_labels(pr: PullRequest) -> List[str]:
     return labels
 
 
+def get_project_url(owner: str, name: str) -> str:
+    return f"https://github.com/{owner}/{name}"
+
+
+def get_repo_name(owner: str, name: str) -> str:
+    return f"{owner}/{name}"
+
+
 def strip_release(message):
     return re.sub(r"^\s*\[[\w,\.,-]*\]\s*", r"", message)

--- a/galaxy_release_util/metadata.py
+++ b/galaxy_release_util/metadata.py
@@ -5,8 +5,6 @@ from github.PullRequest import PullRequest
 
 PROJECT_OWNER = "galaxyproject"
 PROJECT_NAME = "galaxy"
-PROJECT_URL = f"https://github.com/{PROJECT_OWNER}/{PROJECT_NAME}"
-PROJECT_API = f"https://api.github.com/repos/{PROJECT_OWNER}/{PROJECT_NAME}/"
 
 GROUPED_TAGS = dict(
     [

--- a/galaxy_release_util/metadata.py
+++ b/galaxy_release_util/metadata.py
@@ -57,7 +57,7 @@ def _text_target(pull_request: PullRequest, skip_merge=True):
         print(f"No 'kind/*' or 'minor' or 'merge' or 'procedures' label found for {_pr_to_str(pull_request)}")
         text_target = None
 
-    if is_minor or is_merge and skip_merge:
+    if (is_minor or is_merge) and skip_merge:
         return
 
     if is_some_kind_of_enhancement and is_major:

--- a/galaxy_release_util/metadata.py
+++ b/galaxy_release_util/metadata.py
@@ -1,6 +1,7 @@
 import re
 from typing import List
 
+import click
 from github.PullRequest import PullRequest
 
 PROJECT_OWNER = "galaxyproject"
@@ -28,7 +29,7 @@ def _text_target(pull_request: PullRequest, skip_merge=True):
     labels = [label.name.lower() for label in pull_request.labels]
     is_bug = is_enhancement = is_feature = is_minor = is_major = is_merge = is_small_enhancement = False
     if len(labels) == 0:
-        print(f"No labels found for {pr_number}")
+        click.echo(f"No labels found for {pr_number}", err=True)
         return None
     for label_name in labels:
         if label_name == "minor":
@@ -52,7 +53,7 @@ def _text_target(pull_request: PullRequest, skip_merge=True):
     is_some_kind_of_enhancement = is_enhancement or is_feature or is_small_enhancement
 
     if not (is_bug or is_some_kind_of_enhancement or is_minor or is_merge):
-        print(f"No 'kind/*' or 'minor' or 'merge' or 'procedures' label found for {_pr_to_str(pull_request)}")
+        click.echo(f"No 'kind/*' or 'minor' or 'merge' or 'procedures' label found for {_pr_to_str(pull_request)}", err=True)
         text_target = None
 
     if (is_minor or is_merge) and skip_merge:
@@ -81,7 +82,7 @@ def _text_target(pull_request: PullRequest, skip_merge=True):
         else:
             text_target = "bug"
     else:
-        print(f"Logic problem, cannot determine section for {_pr_to_str(pull_request)}")
+        click.echo(f"Logic problem, cannot determine section for {_pr_to_str(pull_request)}", err=True)
         text_target = None
     if text_target:
         text_target += "\n"

--- a/galaxy_release_util/point_release.py
+++ b/galaxy_release_util/point_release.py
@@ -32,7 +32,10 @@ from .cli.options import (
 )
 from .github_client import github_client
 from .metadata import (
+    PROJECT_NAME,
+    PROJECT_OWNER,
     _text_target,
+    get_repo_name,
     strip_release,
 )
 from .util import (
@@ -40,10 +43,7 @@ from .util import (
     version_filepath,
 )
 
-g = github_client()
-PROJECT_OWNER = "galaxyproject"
-PROJECT_NAME = "galaxy"
-REPO = f"{PROJECT_OWNER}/{PROJECT_NAME}"
+REPO = get_repo_name(PROJECT_OWNER, PROJECT_NAME)
 DEFAULT_UPSTREAM_URL = f"https://github.com/{REPO}.git"
 
 HISTORY_TEMPLATE = """History
@@ -292,11 +292,12 @@ def bump_package_version(package: Package, new_version: Version) -> None:
     package.modified_paths.append(package.setup_cfg)
 
 
-def commits_to_prs(packages: List[Package]) -> None:
+def commits_to_prs(packages: List[Package], owner: str = PROJECT_OWNER, repo_name: str = PROJECT_NAME) -> None:
+    g = github_client()
     commits = set.union(*(p.commits for p in packages))
     pr_cache = {}
     commit_to_pr = {}
-    repo = g.get_repo(REPO)
+    repo = g.get_repo(get_repo_name(owner, repo_name))
     total_commits = len(commits)
     for i, commit in enumerate(commits):
         click.echo(f"Processing commit {i + 1} of {total_commits}")

--- a/galaxy_release_util/point_release.py
+++ b/galaxy_release_util/point_release.py
@@ -858,8 +858,15 @@ def merge_changes_into_newer_branches(
 def push_references(galaxy_root: Path, release_tag: str, branches: List[str], upstream: str, no_confirm: bool) -> None:
     references = [release_tag] + branches
     if no_confirm or click.confirm(f"Push {','.join(references)} to upstream '{upstream}' ?", abort=True):
-        for reference in references:
-            subprocess.run(["git", "push", upstream, reference], cwd=galaxy_root).check_returncode()
+        for i, reference in enumerate(references):
+            try:
+                subprocess.run(["git", "push", upstream, reference], cwd=galaxy_root).check_returncode()
+            except subprocess.CalledProcessError:
+                remaining = references[i:]
+                click.echo("\nPush failed. To complete the release, run the following commands manually:")
+                for ref in remaining:
+                    click.echo(f"  git push {upstream} {ref}")
+                raise
 
 
 if __name__ == "__main__":

--- a/galaxy_release_util/point_release.py
+++ b/galaxy_release_util/point_release.py
@@ -300,19 +300,24 @@ def commits_to_prs(packages: List[Package], owner: str = PROJECT_OWNER, repo_nam
     commit_to_pr = {}
     repo = g.get_repo(get_repo_name(owner, repo_name))
     total_commits = len(commits)
+    skipped = []
     for i, commit in enumerate(commits):
         click.echo(f"Processing commit {i + 1} of {total_commits}")
         # Get the list of pull requests associated with the commit
         commit_obj = repo.get_commit(commit)
         prs = commit_obj.get_pulls()
-        if not prs:
-            raise Exception(f"commit {commit} has no associated PRs")
+        if not prs or prs.totalCount == 0:
+            skipped.append(commit)
+            continue
         for pr in prs:
             if pr.number not in pr_cache:
                 pr_cache[pr.number] = pr
             commit_to_pr[commit] = pr_cache[pr.number]
+    if skipped:
+        click.echo(f"Warning: {len(skipped)} commit(s) have no associated PRs (e.g. merge commits):", err=True)
+        for sha in skipped:
+            click.echo(f"  {sha}", err=True)
     for package in packages:
-        # Exclude commits without PRs
         package.prs = set(commit_to_pr[commit] for commit in package.commits if commit in commit_to_pr)
 
 

--- a/galaxy_release_util/point_release.py
+++ b/galaxy_release_util/point_release.py
@@ -45,7 +45,7 @@ from .util import (
 )
 
 REPO = get_repo_name(PROJECT_OWNER, PROJECT_NAME)
-DEFAULT_UPSTREAM_URL = f"https://github.com/{REPO}.git"
+DEFAULT_UPSTREAM_URL = f"git@github.com:{REPO}.git"
 
 HISTORY_TEMPLATE = """History
 -------

--- a/galaxy_release_util/point_release.py
+++ b/galaxy_release_util/point_release.py
@@ -29,6 +29,7 @@ from .cli.options import (
     ClickVersion,
     galaxy_root_option,
     group_options,
+    release_config_option,
 )
 from .github_client import github_client
 from .metadata import (
@@ -38,14 +39,12 @@ from .metadata import (
     get_repo_name,
     strip_release,
 )
+from .release_config import load_repo_owner
 from .util import (
     escape_rst_inline,
     verify_galaxy_root,
     version_filepath,
 )
-
-REPO = get_repo_name(PROJECT_OWNER, PROJECT_NAME)
-DEFAULT_UPSTREAM_URL = f"git@github.com:{REPO}.git"
 
 HISTORY_TEMPLATE = """History
 -------
@@ -230,10 +229,16 @@ def parse_changelog(package: Package) -> List[ChangelogItem]:
     Parser().parse(package.history_rst.read_text(), document)
     changelog_items: List[ChangelogItem] = []
     root_section = document[0]
-    assert isinstance(root_section, docutils.nodes.section)
+    if not isinstance(root_section, docutils.nodes.section):
+        raise ValueError(
+            f"Expected top-level section in {package.history_rst}, got {type(root_section).__name__}"
+        )
     for node in root_section.children:
         # ignore title and comment
-        assert isinstance(node, (docutils.nodes.title, docutils.nodes.comment, docutils.nodes.section)), node
+        if not isinstance(node, (docutils.nodes.title, docutils.nodes.comment, docutils.nodes.section)):
+            raise ValueError(
+                f"Unexpected node type {type(node).__name__} in {package.history_rst}: {node}"
+            )
         if isinstance(node, docutils.nodes.section):
             release_version = node[0].astext()
             current_date = None
@@ -262,9 +267,10 @@ def parse_changelog(package: Package) -> List[ChangelogItem]:
                         if isinstance(section_changelog_item, docutils.nodes.system_message):
                             # Likely a warning that subsection (e.g. Bug fixes) is not unique
                             continue
-                        assert isinstance(section_changelog_item, docutils.nodes.bullet_list), type(
-                            section_changelog_item
-                        )
+                        if not isinstance(section_changelog_item, docutils.nodes.bullet_list):
+                            raise ValueError(
+                                f"Expected bullet list in {package.history_rst}, got {type(section_changelog_item).__name__}"
+                            )
                         for child in section_changelog_item:
                             add_changelog_item(changes, child)
             changelog_items.append(ChangelogItem(version=current_version, date=current_date, changes=changes))
@@ -379,7 +385,11 @@ def upload_package(package: Package) -> None:
 def get_root_version(galaxy_root: Path) -> Version:
     version_py = version_filepath(galaxy_root)
     version_py_contents = version_py.read_text().splitlines()
-    assert len(version_py_contents) == 3
+    if len(version_py_contents) != 3:
+        raise ValueError(
+            f"Expected 3 lines in {version_py}, got {len(version_py_contents)}. "
+            "File should contain VERSION_MAJOR, VERSION_MINOR, and VERSION lines."
+        )
     major_version = version_py_contents[0].split('"')[1]
     minor_version = version_py_contents[1].split('"')[1]
     return Version(f"{major_version}.{minor_version}")
@@ -486,9 +496,12 @@ def merge_and_resolve_branches(
         last_changelog_item: Optional[ChangelogItem] = None
         for changelog_item in sorted(combined_history, key=lambda item: item.version, reverse=True):
             if last_changelog_item and changelog_item.version == last_changelog_item.version:
-                assert (
-                    last_changelog_item.changes == changelog_item.changes
-                ), f"Changelog differs for version {changelog_item.version} of package {new_package.name}, you have to fix this manually.\nOffending lines are {last_changelog_item.changes} and {changelog_item.changes}"
+                if last_changelog_item.changes != changelog_item.changes:
+                    raise ValueError(
+                        f"Changelog differs for version {changelog_item.version} of package {new_package.name}, "
+                        f"you have to fix this manually.\n"
+                        f"Offending lines are {last_changelog_item.changes} and {changelog_item.changes}"
+                    )
                 continue
             if not changelog_item.date and not changelog_item.changes:
                 # dev0 version, we'll inject that later
@@ -662,8 +675,8 @@ def build_and_upload(
 )
 @click.option("--build-packages/--no-build-packages", type=bool, is_flag=True, default=True)
 @click.option("--upload-packages", type=bool, is_flag=True, default=False)
-@click.option("--upstream", type=str, default=DEFAULT_UPSTREAM_URL)
-@group_options(packages_option, no_confirm_option)
+@click.option("--upstream", type=str, default=None, help="Git upstream URL. Default: git@github.com:{owner}/{repo}.git")
+@group_options(release_config_option, packages_option, no_confirm_option)
 def create_point_release(
     galaxy_root: Path,
     new_version: Version,
@@ -672,9 +685,13 @@ def create_point_release(
     package_subset: List[str],
     upload_packages: bool,
     no_confirm: bool,
-    upstream: str,
+    upstream: Optional[str],
+    release_config: Optional[Path],
 ):
     verify_galaxy_root(galaxy_root)
+    owner, repo = load_repo_owner(galaxy_root, new_version, release_config)
+    if upstream is None:
+        upstream = f"git@github.com:{get_repo_name(owner, repo)}.git"
     check_galaxy_repo_is_clean(galaxy_root)
     base_branch = get_current_branch(galaxy_root)
     user_confirmation(galaxy_root, new_version, base_branch, no_confirm)
@@ -687,7 +704,7 @@ def create_point_release(
     set_root_version(version_py, new_version)
     modified_paths = [version_py]
     packages = load_packages(galaxy_root, package_subset, last_commit)
-    commits_to_prs(packages)
+    commits_to_prs(packages, owner, repo)
     update_packages(packages, new_version, modified_paths)
     update_client_version(galaxy_root, new_version, modified_paths)
     run_build_packages(build_packages, packages)

--- a/galaxy_release_util/point_release.py
+++ b/galaxy_release_util/point_release.py
@@ -39,6 +39,7 @@ from .metadata import (
     strip_release,
 )
 from .util import (
+    escape_rst_inline,
     verify_galaxy_root,
     version_filepath,
 )
@@ -337,8 +338,9 @@ def get_package_history(package: Package, new_version: Version) -> ChangelogItem
                     category = "Bug fixes"
                 if "enhancement" in text_target or "feature" in text_target:
                     category = "Enhancements"
+            title = escape_rst_inline(strip_release(pr.title))
             changes[category].append(
-                f"* {strip_release(pr.title)} by `@{pr.user.login} <https://github.com/{pr.user.login}>`_ in `#{pr.number} <{pr.html_url}>`_"
+                f"* {title} by `@{pr.user.login} <https://github.com/{pr.user.login}>`_ in `#{pr.number} <{pr.html_url}>`_"
             )
 
     for kind, entries in changes.items():

--- a/galaxy_release_util/release_config.py
+++ b/galaxy_release_util/release_config.py
@@ -13,7 +13,7 @@ class ReleaseConfig:
     previous_version: Version
     next_version: Version
     release_date: datetime.date
-    freeze_date: Optional[datetime.date] = None
+    freeze_date: datetime.date
     owner: str = "galaxyproject"
     repo: str = "galaxy"
 
@@ -57,6 +57,8 @@ def load_release_config(
         missing.append("--next-version")
     if release_date is None:
         missing.append("--release-date")
+    if freeze_date is None:
+        missing.append("--freeze-date")
     if missing:
         raise ValueError(
             f"No release config YAML found and missing required flag(s): {', '.join(missing)}. "
@@ -94,7 +96,7 @@ def _load_yaml_file(path: Path, release_version: Version) -> ReleaseConfig:
         data = yaml.safe_load(f)
     if not isinstance(data, dict):
         raise ValueError(f"Release config must be a YAML mapping, got {type(data).__name__} in {path}")
-    required_fields = ["current-version", "previous-version", "next-version", "release-date"]
+    required_fields = ["current-version", "previous-version", "next-version", "freeze-date", "release-date"]
     missing = [f for f in required_fields if f not in data]
     if missing:
         raise ValueError(
@@ -121,14 +123,10 @@ def _load_yaml_file(path: Path, release_version: Version) -> ReleaseConfig:
         release_date = _parse_date(data["release-date"])
     except Exception as e:
         raise ValueError(f"Invalid 'release-date' value {data['release-date']!r} in {path}: {e}")
-    freeze_date: Optional[datetime.date] = None
-    if "freeze-date" in data:
-        if data["freeze-date"] is None:
-            raise ValueError(f"Field 'freeze-date' is present but has no value in {path}")
-        try:
-            freeze_date = _parse_date(data["freeze-date"])
-        except Exception as e:
-            raise ValueError(f"Invalid 'freeze-date' value {data['freeze-date']!r} in {path}: {e}")
+    try:
+        freeze_date = _parse_date(data["freeze-date"])
+    except Exception as e:
+        raise ValueError(f"Invalid 'freeze-date' value {data['freeze-date']!r} in {path}: {e}")
     if current_version != release_version:
         raise ValueError(
             f"'current-version' in config ({current_version}) does not match "

--- a/galaxy_release_util/release_config.py
+++ b/galaxy_release_util/release_config.py
@@ -1,0 +1,153 @@
+import datetime
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from packaging.version import Version
+
+
+@dataclass
+class ReleaseConfig:
+    current_version: Version
+    previous_version: Version
+    next_version: Version
+    release_date: datetime.date
+    freeze_date: Optional[datetime.date] = None
+    owner: str = "galaxyproject"
+    repo: str = "galaxy"
+
+
+def load_release_config(
+    galaxy_root: Path,
+    release_version: Version,
+    release_config_path: Optional[Path] = None,
+    previous_version: Optional[Version] = None,
+    next_version: Optional[Version] = None,
+    release_date: Optional[datetime.date] = None,
+    freeze_date: Optional[datetime.date] = None,
+) -> ReleaseConfig:
+    """Load release config from YAML, CLI flags, or both.
+
+    Resolution order:
+    1. If --release-config is given, load that file (must exist).
+    2. Otherwise, try the default path {galaxy_root}/doc/source/releases/release_{version}.yml.
+    3. CLI flags (--previous-version, --next-version, --release-date, --freeze-date) override YAML values.
+    4. If no YAML is found, all required values must come from CLI flags.
+    """
+    yaml_config = _try_load_yaml_config(galaxy_root, release_version, release_config_path)
+
+    if yaml_config is not None:
+        # Apply CLI overrides
+        if previous_version is not None:
+            yaml_config.previous_version = previous_version
+        if next_version is not None:
+            yaml_config.next_version = next_version
+        if release_date is not None:
+            yaml_config.release_date = release_date
+        if freeze_date is not None:
+            yaml_config.freeze_date = freeze_date
+        return yaml_config
+
+    # No YAML found — build entirely from CLI flags
+    missing = []
+    if previous_version is None:
+        missing.append("--previous-version")
+    if next_version is None:
+        missing.append("--next-version")
+    if release_date is None:
+        missing.append("--release-date")
+    if missing:
+        raise ValueError(
+            f"No release config YAML found and missing required flag(s): {', '.join(missing)}. "
+            f"Provide a config YAML via --release-config or supply the flags directly."
+        )
+    return ReleaseConfig(
+        current_version=release_version,
+        previous_version=previous_version,
+        next_version=next_version,
+        release_date=release_date,
+        freeze_date=freeze_date,
+    )
+
+
+def _try_load_yaml_config(
+    galaxy_root: Path,
+    release_version: Version,
+    release_config_path: Optional[Path],
+) -> Optional[ReleaseConfig]:
+    """Try to load a YAML config file, returning None if no file is found at the default path."""
+    if release_config_path is not None:
+        if not release_config_path.exists():
+            raise FileNotFoundError(f"Release config not found: {release_config_path}")
+        return _load_yaml_file(release_config_path, release_version)
+
+    default_path = galaxy_root / "doc" / "source" / "releases" / f"release_{release_version}.yml"
+    if not default_path.exists():
+        return None
+    return _load_yaml_file(default_path, release_version)
+
+
+def _load_yaml_file(path: Path, release_version: Version) -> ReleaseConfig:
+    """Load and validate a YAML release config file."""
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"Release config must be a YAML mapping, got {type(data).__name__} in {path}")
+    required_fields = ["current-version", "previous-version", "next-version", "release-date"]
+    missing = [f for f in required_fields if f not in data]
+    if missing:
+        raise ValueError(
+            f"Missing required field(s) {', '.join(repr(f) for f in missing)} in {path}"
+        )
+    for field in required_fields:
+        if data[field] is None:
+            raise ValueError(f"Field '{field}' is present but has no value in {path}")
+    try:
+        current_version = Version(str(data["current-version"]))
+    except Exception as e:
+        raise ValueError(f"Invalid 'current-version' value {data['current-version']!r} in {path}: {e}")
+    try:
+        previous_version = Version(str(data["previous-version"]))
+    except Exception as e:
+        raise ValueError(
+            f"Invalid 'previous-version' value {data['previous-version']!r} in {path}: {e}"
+        )
+    try:
+        next_version = Version(str(data["next-version"]))
+    except Exception as e:
+        raise ValueError(f"Invalid 'next-version' value {data['next-version']!r} in {path}: {e}")
+    try:
+        release_date = _parse_date(data["release-date"])
+    except Exception as e:
+        raise ValueError(f"Invalid 'release-date' value {data['release-date']!r} in {path}: {e}")
+    freeze_date: Optional[datetime.date] = None
+    if "freeze-date" in data:
+        if data["freeze-date"] is None:
+            raise ValueError(f"Field 'freeze-date' is present but has no value in {path}")
+        try:
+            freeze_date = _parse_date(data["freeze-date"])
+        except Exception as e:
+            raise ValueError(f"Invalid 'freeze-date' value {data['freeze-date']!r} in {path}: {e}")
+    if current_version != release_version:
+        raise ValueError(
+            f"'current-version' in config ({current_version}) does not match "
+            f"release-version argument ({release_version})"
+        )
+    owner = data.get("owner", "galaxyproject")
+    repo = data.get("repo", "galaxy")
+    return ReleaseConfig(
+        current_version=current_version,
+        previous_version=previous_version,
+        next_version=next_version,
+        release_date=release_date,
+        freeze_date=freeze_date,
+        owner=owner,
+        repo=repo,
+    )
+
+
+def _parse_date(value) -> datetime.date:
+    if isinstance(value, datetime.date):
+        return value
+    return datetime.datetime.strptime(str(value), "%Y-%m-%d").date()

--- a/galaxy_release_util/release_config.py
+++ b/galaxy_release_util/release_config.py
@@ -147,6 +147,33 @@ def _load_yaml_file(path: Path, release_version: Version) -> ReleaseConfig:
     )
 
 
+def load_repo_owner(
+    galaxy_root: Path,
+    release_version: Version,
+    release_config_path: Optional[Path] = None,
+) -> tuple:
+    """Load owner and repo from release config YAML.
+
+    For point releases (e.g. 26.0.1), derives the major.minor version (26.0)
+    to locate the config file. Returns (owner, repo) tuple, falling back to
+    defaults only if no config file exists at the default path.
+    """
+    major_minor = Version(f"{release_version.major}.{release_version.minor}")
+    if release_config_path is not None:
+        if not release_config_path.exists():
+            raise FileNotFoundError(f"Release config not found: {release_config_path}")
+        path = release_config_path
+    else:
+        path = galaxy_root / "doc" / "source" / "releases" / f"release_{major_minor}.yml"
+        if not path.exists():
+            return ("galaxyproject", "galaxy")
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"Release config must be a YAML mapping, got {type(data).__name__} in {path}")
+    return (data.get("owner", "galaxyproject"), data.get("repo", "galaxy"))
+
+
 def _parse_date(value) -> datetime.date:
     if isinstance(value, datetime.date):
         return value

--- a/galaxy_release_util/util.py
+++ b/galaxy_release_util/util.py
@@ -1,5 +1,13 @@
 import os
+import re
 from pathlib import Path
+
+_RST_INLINE_MARKUP_RE = re.compile(r"([`*|\\])")
+
+
+def escape_rst_inline(text: str) -> str:
+    """Escape characters that have special meaning in RST inline markup."""
+    return _RST_INLINE_MARKUP_RE.sub(r"\\\1", text)
 
 
 def version_filepath(galaxy_root: Path) -> Path:

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     docutils
     packaging
     PyGithub
+    PyYAML
     requests
     twine
 packages = find:

--- a/tests/test_bootstrap_history.py
+++ b/tests/test_bootstrap_history.py
@@ -3,12 +3,9 @@ from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
-from packaging.version import Version
 
 from galaxy_release_util import bootstrap_history
 from galaxy_release_util.bootstrap_history import (
-    _get_previous_release_version,
-    _get_release_version_strings,
     check_blocking_issues,
     check_blocking_prs,
     create_changelog,
@@ -42,53 +39,6 @@ def next_release_announcement_file(release_files_dir):
 def prs_file(release_files_dir):
     with open(release_files_dir / "98.2_prs.rst") as f:
         return f.read()
-
-
-def test_get_previous_release_version(monkeypatch):
-    monkeypatch.setattr(
-        bootstrap_history, "_get_release_version_strings", lambda x: sorted(["22.01", "22.05", "23.0", "23.1"])
-    )
-
-    assert _get_previous_release_version(None, Version("15.1")) is None
-    assert _get_previous_release_version(None, Version("22.01")) is None
-    assert _get_previous_release_version(None, Version("22.05")) == Version("22.01")
-    assert _get_previous_release_version(None, Version("23.0")) == Version("22.05")
-    assert _get_previous_release_version(None, Version("23.1")) == Version("23.0")
-    assert _get_previous_release_version(None, Version("23.2")) == Version("23.1")
-    assert _get_previous_release_version(None, Version("99.99")) == Version("23.1")
-
-
-def test_get_release_version_strings(monkeypatch):
-    filenames = [
-        "15.0.not_rst",
-        "22.01.rst",
-        "22.05.rst",
-        "23.0.rst",
-        "23.1.rst",
-        "23.not_a_release.rst",
-        "not_a_release.23.rst",
-    ]
-    monkeypatch.setattr(bootstrap_history, "_get_release_documentation_filenames", lambda x: sorted(filenames))
-    assert _get_release_version_strings(None) == ["22.01", "22.05", "23.0", "23.1"]
-
-
-def test_get_release_version_strings_rstrip_regression(monkeypatch):
-    """Verify that filenames ending with characters in '.rst' are handled correctly.
-
-    The old implementation used f.rstrip('.rst') which strips individual characters,
-    not the suffix. For example, 'foo.rst'.rstrip('.rst') would strip trailing
-    r, s, t, and . characters. This test verifies the fix.
-    """
-    filenames = [
-        "22.01.rst",
-        "23.0.rst",
-    ]
-    monkeypatch.setattr(bootstrap_history, "_get_release_documentation_filenames", lambda x: sorted(filenames))
-    result = _get_release_version_strings(None)
-    assert result == ["22.01", "23.0"]
-    # These must preserve the full version string before .rst
-    assert "22.01" in result
-    assert "23.0" in result
 
 
 def test_create_changelog(

--- a/tests/test_bootstrap_history.py
+++ b/tests/test_bootstrap_history.py
@@ -114,6 +114,7 @@ def test_check_blocking_prs_dry_run(monkeypatch):
             "previous-version: '98.1'\n"
             "next-version: '99.0'\n"
             "release-date: '2099-01-15'\n"
+            "freeze-date: '2099-01-01'\n"
         )
         config_path = Path("doc/source/releases/release_98.2.yml")
         config_path.write_text(config_content)
@@ -134,6 +135,7 @@ def test_check_blocking_issues_dry_run(monkeypatch):
             "previous-version: '98.1'\n"
             "next-version: '99.0'\n"
             "release-date: '2099-01-15'\n"
+            "freeze-date: '2099-01-01'\n"
         )
         config_path = Path("doc/source/releases/release_98.2.yml")
         config_path.write_text(config_content)
@@ -154,6 +156,7 @@ def test_create_release_issue_rejects_invalid_next_version(monkeypatch):
             "previous-version: '98.1'\n"
             "next-version: '98.0'\n"
             "release-date: '2099-01-15'\n"
+            "freeze-date: '2099-01-01'\n"
         )
         Path("doc/source/releases/release_98.2.yml").write_text(config_content)
         result = runner.invoke(
@@ -179,4 +182,5 @@ def test_create_release_issue_rejects_missing_freeze_date(monkeypatch):
             create_release_issue, ["98.2", "--galaxy-root", ".", "--dry-run"]
         )
         assert result.exit_code != 0
-        assert "freeze-date is required" in result.output
+        assert "Missing required field" in str(result.exception)
+        assert "freeze-date" in str(result.exception)

--- a/tests/test_bootstrap_history.py
+++ b/tests/test_bootstrap_history.py
@@ -20,12 +20,6 @@ def release_files_dir():
 
 
 @pytest.fixture
-def release_file(release_files_dir):
-    with open(release_files_dir / "98.2.rst") as f:
-        return f.read()
-
-
-@pytest.fixture
 def announcement_file(release_files_dir):
     with open(release_files_dir / "98.2_announce.rst") as f:
         return f.read()
@@ -84,7 +78,6 @@ def test_get_release_version_strings(monkeypatch):
 
 def test_create_changelog(
     monkeypatch,
-    release_file,
     announcement_file,
     user_announcement_file,
     prs_file,
@@ -104,8 +97,6 @@ def test_create_changelog(
 
         releases_path = Path("doc") / "source" / "releases"
 
-        with open(releases_path / "98.2.rst") as f:
-            assert f.read() == release_file
         with open(releases_path / "98.2_announce.rst") as f:
             assert f.read() == announcement_file
         with open(releases_path / "98.2_announce_user.rst") as f:

--- a/tests/test_bootstrap_history.py
+++ b/tests/test_bootstrap_history.py
@@ -104,6 +104,7 @@ def test_create_changelog_dry_run(monkeypatch):
 
 
 def test_check_blocking_prs_dry_run(monkeypatch):
+    monkeypatch.setattr(bootstrap_history, "verify_galaxy_root", lambda x: None)
     runner = CliRunner()
     with runner.isolated_filesystem():
         os.makedirs("doc/source/releases")
@@ -123,6 +124,7 @@ def test_check_blocking_prs_dry_run(monkeypatch):
 
 
 def test_check_blocking_issues_dry_run(monkeypatch):
+    monkeypatch.setattr(bootstrap_history, "verify_galaxy_root", lambda x: None)
     runner = CliRunner()
     with runner.isolated_filesystem():
         os.makedirs("doc/source/releases")

--- a/tests/test_bootstrap_history.py
+++ b/tests/test_bootstrap_history.py
@@ -161,3 +161,22 @@ def test_create_release_issue_rejects_invalid_next_version(monkeypatch):
         )
         assert result.exit_code != 0
         assert "Next release version should be greater than current version" in str(result.exception)
+
+
+def test_create_release_issue_rejects_missing_freeze_date(monkeypatch):
+    monkeypatch.setattr(bootstrap_history, "verify_galaxy_root", lambda x: None)
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        os.makedirs("doc/source/releases")
+        config_content = (
+            "current-version: '98.2'\n"
+            "previous-version: '98.1'\n"
+            "next-version: '99.0'\n"
+            "release-date: '2099-01-15'\n"
+        )
+        Path("doc/source/releases/release_98.2.yml").write_text(config_content)
+        result = runner.invoke(
+            create_release_issue, ["98.2", "--galaxy-root", ".", "--dry-run"]
+        )
+        assert result.exit_code != 0
+        assert "freeze-date is required" in result.output

--- a/tests/test_bootstrap_history.py
+++ b/tests/test_bootstrap_history.py
@@ -60,14 +60,13 @@ def test_create_changelog(
         config_content = (
             "current-version: '98.2'\n"
             "previous-version: '98.1'\n"
-            "next-version: '99.0'\n"
             "release-date: '2099-01-15'\n"
             "freeze-date: '2099-01-01'\n"
         )
         config_path = Path("doc/source/releases/release_98.2.yml")
         config_path.write_text(config_content)
         result = runner.invoke(
-            create_changelog, ["98.2", "--galaxy-root", "."]
+            create_changelog, ["98.2", "--galaxy-root", ".", "--next-version", "99.0"]
         )  # version 98.2 to be released on January 15, 2099
         assert result.exit_code == 0, result.output
 
@@ -91,14 +90,13 @@ def test_create_changelog_dry_run(monkeypatch):
         config_content = (
             "current-version: '98.2'\n"
             "previous-version: '98.1'\n"
-            "next-version: '99.0'\n"
             "release-date: '2099-01-15'\n"
             "freeze-date: '2099-01-01'\n"
         )
         config_path = Path("doc/source/releases/release_98.2.yml")
         config_path.write_text(config_content)
         result = runner.invoke(
-            create_changelog, ["98.2", "--galaxy-root", ".", "--dry-run"]
+            create_changelog, ["98.2", "--galaxy-root", ".", "--next-version", "99.0", "--dry-run"]
         )
         assert result.exit_code == 0, result.output
         assert "Dry run: skipping GitHub API call" in result.output
@@ -112,7 +110,6 @@ def test_check_blocking_prs_dry_run(monkeypatch):
         config_content = (
             "current-version: '98.2'\n"
             "previous-version: '98.1'\n"
-            "next-version: '99.0'\n"
             "release-date: '2099-01-15'\n"
             "freeze-date: '2099-01-01'\n"
         )
@@ -133,7 +130,6 @@ def test_check_blocking_issues_dry_run(monkeypatch):
         config_content = (
             "current-version: '98.2'\n"
             "previous-version: '98.1'\n"
-            "next-version: '99.0'\n"
             "release-date: '2099-01-15'\n"
             "freeze-date: '2099-01-01'\n"
         )
@@ -154,13 +150,12 @@ def test_create_release_issue_rejects_invalid_next_version(monkeypatch):
         config_content = (
             "current-version: '98.2'\n"
             "previous-version: '98.1'\n"
-            "next-version: '98.0'\n"
             "release-date: '2099-01-15'\n"
             "freeze-date: '2099-01-01'\n"
         )
         Path("doc/source/releases/release_98.2.yml").write_text(config_content)
         result = runner.invoke(
-            create_release_issue, ["98.2", "--galaxy-root", ".", "--dry-run"]
+            create_release_issue, ["98.2", "--galaxy-root", ".", "--next-version", "98.0", "--dry-run"]
         )
         assert result.exit_code != 0
         assert "Next release version should be greater than current version" in str(result.exception)
@@ -174,12 +169,11 @@ def test_create_release_issue_rejects_missing_freeze_date(monkeypatch):
         config_content = (
             "current-version: '98.2'\n"
             "previous-version: '98.1'\n"
-            "next-version: '99.0'\n"
             "release-date: '2099-01-15'\n"
         )
         Path("doc/source/releases/release_98.2.yml").write_text(config_content)
         result = runner.invoke(
-            create_release_issue, ["98.2", "--galaxy-root", ".", "--dry-run"]
+            create_release_issue, ["98.2", "--galaxy-root", ".", "--next-version", "99.0", "--dry-run"]
         )
         assert result.exit_code != 0
         assert "Missing required field" in str(result.exception)

--- a/tests/test_bootstrap_history.py
+++ b/tests/test_bootstrap_history.py
@@ -158,7 +158,7 @@ def test_create_release_issue_rejects_invalid_next_version(monkeypatch):
             create_release_issue, ["98.2", "--galaxy-root", ".", "--next-version", "98.0", "--dry-run"]
         )
         assert result.exit_code != 0
-        assert "Next release version should be greater than current version" in str(result.exception)
+        assert "--next-version (98.0) must be greater than release version (98.2)" in result.output
 
 
 def test_create_release_issue_rejects_missing_freeze_date(monkeypatch):

--- a/tests/test_data/98.2_announce.rst
+++ b/tests/test_data/98.2_announce.rst
@@ -5,25 +5,8 @@
 
 .. include:: _header.rst
 
-Highlights
-===========================================================
-
-Feature1
---------
-
-Feature description.
-
-Feature2
---------
-
-Feature description.
-
-Feature3
---------
-
-Feature description.
-
 Please see the `98.2 user release notes <98.2_announce_user.html>`__ for a summary of new user features.
+The `GitHub Release Notes <https://github.com/galaxyproject/galaxy/releases/tag/v98.2.0>`__ provide a comprehensive overview of all changes.
 
 Get Galaxy
 ===========================================================
@@ -49,7 +32,9 @@ Add content or drop section.
 
 Configuration Changes
 ===========================================================
-Add content or drop section.
+Run ``python scripts/release-diff.py release_<previous_version>`` in the Galaxy root directory
+to get a diff of configuration changes between releases.
+Add any more content or drop section if it's empty.
 
 Deprecation Notices
 ===========================================================
@@ -58,12 +43,6 @@ Add content or drop section.
 Developer Notes
 ===========================================================
 Add content or drop section.
-
-Release Notes
-===========================================================
-
-.. include:: 98.2.rst
-   :start-after: announce_start
 
 Release Team
 ===========================================================

--- a/tests/test_data/98.2_announce_user.rst
+++ b/tests/test_data/98.2_announce_user.rst
@@ -5,33 +5,37 @@
 
 .. include:: _header.rst
 
-Please see the full :doc:`98.2 release notes <98.2_announce>` for more details.
+Please see the full `release notes <https://github.com/galaxyproject/galaxy/releases/tag/v98.2.0>`__ for more details.
 
 Highlights
 ===========================================================
 
+Discover some of the exciting new features, enhancements, and improvements in Galaxy 98.2.
+
 Feature1
 --------
 
-Feature description.
+A description of the feature and its main highlights. Include screenshots/videos if applicable.
 
 Feature2
 --------
 
-Feature description.
+A description of the feature and its main highlights. Include screenshots/videos if applicable.
 
 Feature3
 --------
 
-Feature description.
+A description of the feature and its main highlights. Include screenshots/videos if applicable.
 
 
-Visualizations
+----
+
+Visualizations Updates
 ===========================================================
 
 .. visualizations
 
-Datatypes
+Datatypes Updates
 ===========================================================
 
 .. datatypes
@@ -41,7 +45,8 @@ Builtin Tool Updates
 
 .. tools
 
-Please see the full :doc:`98.2 release notes <98.2_announce>` for more details.
+Please see the full `release notes <https://github.com/galaxyproject/galaxy/releases/tag/v98.2.0>`__ for more details.
+The admin-facing release notes are available :doc:`here <98.2_announce>`.
 
 .. include:: 98.2_prs.rst
 

--- a/tests/test_data/release_98.2.yml
+++ b/tests/test_data/release_98.2.yml
@@ -1,0 +1,5 @@
+current-version: "98.2"
+previous-version: "98.1"
+next-version: "99.0"
+freeze-date: "2099-01-01"
+release-date: "2099-01-15"

--- a/tests/test_data/release_98.2.yml
+++ b/tests/test_data/release_98.2.yml
@@ -1,5 +1,4 @@
 current-version: "98.2"
 previous-version: "98.1"
-next-version: "99.0"
 freeze-date: "2099-01-01"
 release-date: "2099-01-15"

--- a/tests/test_point_release.py
+++ b/tests/test_point_release.py
@@ -1,0 +1,203 @@
+import pathlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+from packaging.version import Version
+
+from galaxy_release_util.point_release import (
+    Package,
+    commits_to_prs,
+    parse_changelog,
+    read_package,
+)
+
+SETUP_CFG_CONTENTS = """\
+[metadata]
+name = galaxy-app
+version = 23.0.2
+author = Galaxy Project
+"""
+
+HISTORY_RST_SIMPLE = """\
+History
+-------
+
+.. to_doc
+
+-------------------
+23.0.2 (2024-01-15)
+-------------------
+
+* Fix bug in tool loading
+* Improve performance of history queries
+
+-------------------
+23.0.1 (2024-01-01)
+-------------------
+
+* Initial point release
+"""
+
+HISTORY_RST_WITH_SECTIONS = """\
+History
+-------
+
+.. to_doc
+
+-------------------
+23.0.2 (2024-01-15)
+-------------------
+
+Bug fixes
+=========
+
+* Fix bug in tool loading
+
+Enhancements
+============
+
+* Improve performance of history queries
+
+-------------------
+23.0.1 (2024-01-01)
+-------------------
+
+* Initial point release
+"""
+
+HISTORY_RST_DEV = """\
+History
+-------
+
+.. to_doc
+
+-----------
+23.0.3.dev0
+-----------
+
+-------------------
+23.0.2 (2024-01-15)
+-------------------
+
+* Fix bug in tool loading
+"""
+
+HISTORY_RST_BAD_STRUCTURE = """\
+Not a real RST document
+"""
+
+
+def _write_package(tmp_path: pathlib.Path, setup_cfg: str = SETUP_CFG_CONTENTS, history_rst: str = HISTORY_RST_SIMPLE):
+    pkg_path = tmp_path / "galaxy-app"
+    pkg_path.mkdir()
+    (pkg_path / "setup.cfg").write_text(setup_cfg)
+    (pkg_path / "HISTORY.rst").write_text(history_rst)
+    return pkg_path
+
+
+class TestReadPackage:
+    def test_basic(self, tmp_path):
+        pkg_path = _write_package(tmp_path)
+        package = read_package(pkg_path)
+        assert package.current_version == "23.0.2"
+        assert package.name == "galaxy-app"
+        assert len(package.package_history) > 0
+
+    def test_missing_version(self, tmp_path):
+        pkg_path = tmp_path / "broken"
+        pkg_path.mkdir()
+        (pkg_path / "setup.cfg").write_text("[metadata]\nname = broken\n")
+        (pkg_path / "HISTORY.rst").write_text(HISTORY_RST_SIMPLE)
+        with pytest.raises(ValueError, match="does not contain version line"):
+            read_package(pkg_path)
+
+
+class TestParseChangelog:
+    def test_simple_changelog(self, tmp_path):
+        pkg_path = _write_package(tmp_path)
+        package = Package(path=pkg_path, current_version="23.0.2")
+        items = parse_changelog(package)
+        assert len(items) == 2
+        assert items[0].version == Version("23.0.2")
+        assert items[0].date == "2024-01-15"
+        assert len(items[0].changes) == 2
+        assert "Fix bug in tool loading" in items[0].changes[0]
+        assert items[1].version == Version("23.0.1")
+
+    def test_sectioned_changelog(self, tmp_path):
+        pkg_path = _write_package(tmp_path, history_rst=HISTORY_RST_WITH_SECTIONS)
+        package = Package(path=pkg_path, current_version="23.0.2")
+        items = parse_changelog(package)
+        assert len(items) == 2
+        # The sectioned entry should have section headers and items
+        changes_text = "\n".join(items[0].changes)
+        assert "Bug fixes" in changes_text
+        assert "Enhancements" in changes_text
+        assert "Fix bug in tool loading" in changes_text
+
+    def test_dev_release_filtered(self, tmp_path):
+        pkg_path = _write_package(tmp_path, history_rst=HISTORY_RST_DEV)
+        package = Package(path=pkg_path, current_version="23.0.3.dev0")
+        items = parse_changelog(package)
+        # Dev release without changes should be filtered out
+        assert len(items) == 1
+        assert items[0].version == Version("23.0.2")
+
+    def test_bad_structure_raises(self, tmp_path):
+        pkg_path = _write_package(tmp_path, history_rst=HISTORY_RST_BAD_STRUCTURE)
+        package = Package(path=pkg_path, current_version="23.0.2")
+        with pytest.raises(ValueError, match="Expected top-level section"):
+            parse_changelog(package)
+
+
+class TestCommitsToPrs:
+    def test_commits_mapped_to_prs(self):
+        mock_pr = MagicMock()
+        mock_pr.number = 42
+        mock_pr.title = "Fix something"
+
+        mock_pulls = MagicMock()
+        mock_pulls.totalCount = 1
+        mock_pulls.__iter__ = MagicMock(return_value=iter([mock_pr]))
+        mock_pulls.__bool__ = MagicMock(return_value=True)
+
+        mock_commit = MagicMock()
+        mock_commit.get_pulls.return_value = mock_pulls
+
+        mock_repo = MagicMock()
+        mock_repo.get_commit.return_value = mock_commit
+
+        mock_github = MagicMock()
+        mock_github.get_repo.return_value = mock_repo
+
+        package = Package(path=pathlib.Path("/fake"), current_version="1.0")
+        package.commits = {"abc123"}
+
+        with patch("galaxy_release_util.point_release.github_client", return_value=mock_github):
+            commits_to_prs([package])
+
+        assert len(package.prs) == 1
+        pr = next(iter(package.prs))
+        assert pr.number == 42
+
+    def test_commits_without_prs_skipped(self):
+        mock_pulls = MagicMock()
+        mock_pulls.totalCount = 0
+        mock_pulls.__bool__ = MagicMock(return_value=False)
+
+        mock_commit = MagicMock()
+        mock_commit.get_pulls.return_value = mock_pulls
+
+        mock_repo = MagicMock()
+        mock_repo.get_commit.return_value = mock_commit
+
+        mock_github = MagicMock()
+        mock_github.get_repo.return_value = mock_repo
+
+        package = Package(path=pathlib.Path("/fake"), current_version="1.0")
+        package.commits = {"abc123", "def456"}
+
+        with patch("galaxy_release_util.point_release.github_client", return_value=mock_github):
+            commits_to_prs([package])
+
+        assert len(package.prs) == 0

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,8 +1,10 @@
+import inspect
 import pathlib
 
 import pytest
 from packaging.version import Version
 
+import galaxy_release_util.point_release as point_release_module
 from galaxy_release_util.point_release import (
     get_major_minor_version_strings,
     get_next_devN_version,
@@ -75,3 +77,16 @@ def test_get_major_minor_version_strings():
     major, minor = get_major_minor_version_strings(version)
     assert major == "21.0"
     assert minor == "0"
+
+
+def test_no_module_level_github_client():
+    """Verify that point_release module does not create a GitHub client at import time."""
+    source = inspect.getsource(point_release_module)
+    # The module should not have a top-level `g = github_client()` call.
+    # github_client() should only be called inside functions.
+    lines = source.splitlines()
+    for line in lines:
+        stripped = line.strip()
+        # Skip comments and lines inside functions/classes (indented)
+        if line and not line[0].isspace() and "github_client()" in stripped and not stripped.startswith("#"):
+            pytest.fail(f"Module-level github_client() call found: {line}")

--- a/tests/test_release_config.py
+++ b/tests/test_release_config.py
@@ -24,12 +24,12 @@ def test_load_release_config_default_path(tmp_path, config_dir):
     _write_config(
         config_dir,
         "release_98.2.yml",
-        "current-version: '98.2'\nprevious-version: '98.1'\nnext-version: '99.0'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
+        "current-version: '98.2'\nprevious-version: '98.1'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
     )
     config = load_release_config(tmp_path, Version("98.2"))
     assert config.current_version == Version("98.2")
     assert config.previous_version == Version("98.1")
-    assert config.next_version == Version("99.0")
+    assert config.next_version is None
     assert config.release_date == datetime.date(2099, 1, 15)
     assert config.freeze_date == datetime.date(2099, 1, 1)
     assert config.owner == "galaxyproject"
@@ -40,12 +40,12 @@ def test_load_release_config_explicit_path(tmp_path, config_dir):
     path = _write_config(
         config_dir,
         "custom.yml",
-        "current-version: '25.0'\nprevious-version: '24.2'\nnext-version: '25.1'\nrelease-date: '2025-07-01'\nfreeze-date: '2025-06-01'\nowner: myorg\nrepo: myrepo\n",
+        "current-version: '25.0'\nprevious-version: '24.2'\nrelease-date: '2025-07-01'\nfreeze-date: '2025-06-01'\nowner: myorg\nrepo: myrepo\n",
     )
     config = load_release_config(tmp_path, Version("25.0"), release_config_path=path)
     assert config.current_version == Version("25.0")
     assert config.previous_version == Version("24.2")
-    assert config.next_version == Version("25.1")
+    assert config.next_version is None
     assert config.release_date == datetime.date(2025, 7, 1)
     assert config.freeze_date == datetime.date(2025, 6, 1)
     assert config.owner == "myorg"
@@ -69,13 +69,12 @@ def test_load_release_config_cli_only(tmp_path):
         tmp_path,
         Version("99.0"),
         previous_version=Version("98.0"),
-        next_version=Version("99.1"),
         release_date=datetime.date(2099, 1, 15),
         freeze_date=datetime.date(2099, 1, 1),
     )
     assert config.current_version == Version("99.0")
     assert config.previous_version == Version("98.0")
-    assert config.next_version == Version("99.1")
+    assert config.next_version is None
     assert config.release_date == datetime.date(2099, 1, 15)
     assert config.freeze_date == datetime.date(2099, 1, 1)
     assert config.owner == "galaxyproject"
@@ -87,7 +86,7 @@ def test_load_release_config_cli_overrides_yaml(tmp_path, config_dir):
     _write_config(
         config_dir,
         "release_98.2.yml",
-        "current-version: '98.2'\nprevious-version: '98.1'\nnext-version: '99.0'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
+        "current-version: '98.2'\nprevious-version: '98.1'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
     )
     config = load_release_config(
         tmp_path, Version("98.2"),
@@ -110,11 +109,22 @@ def test_load_release_config_missing_field(tmp_path, config_dir):
         load_release_config(tmp_path, Version("99.0"))
 
 
+def test_load_release_config_next_version_from_yaml(tmp_path, config_dir):
+    """next-version is still parsed from YAML if present (backward compat)."""
+    _write_config(
+        config_dir,
+        "release_98.2.yml",
+        "current-version: '98.2'\nprevious-version: '98.1'\nnext-version: '99.0'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
+    )
+    config = load_release_config(tmp_path, Version("98.2"))
+    assert config.next_version == Version("99.0")
+
+
 def test_load_release_config_null_required_field(tmp_path, config_dir):
     _write_config(
         config_dir,
         "release_99.0.yml",
-        "current-version: '99.0'\nprevious-version:\nnext-version: '99.1'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
+        "current-version: '99.0'\nprevious-version:\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
     )
     with pytest.raises(ValueError, match="has no value"):
         load_release_config(tmp_path, Version("99.0"))
@@ -124,7 +134,7 @@ def test_load_release_config_invalid_version(tmp_path, config_dir):
     _write_config(
         config_dir,
         "release_99.0.yml",
-        "current-version: '!!!'\nprevious-version: '98.0'\nnext-version: '99.1'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
+        "current-version: '!!!'\nprevious-version: '98.0'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
     )
     with pytest.raises(ValueError, match="Invalid 'current-version'"):
         load_release_config(tmp_path, Version("99.0"))
@@ -134,7 +144,7 @@ def test_load_release_config_invalid_date(tmp_path, config_dir):
     _write_config(
         config_dir,
         "release_99.0.yml",
-        "current-version: '99.0'\nprevious-version: '98.0'\nnext-version: '99.1'\nfreeze-date: '2099-01-01'\nrelease-date: 'not-a-date'\n",
+        "current-version: '99.0'\nprevious-version: '98.0'\nfreeze-date: '2099-01-01'\nrelease-date: 'not-a-date'\n",
     )
     with pytest.raises(ValueError, match="Invalid 'release-date'"):
         load_release_config(tmp_path, Version("99.0"))
@@ -144,7 +154,7 @@ def test_load_release_config_null_freeze_date(tmp_path, config_dir):
     _write_config(
         config_dir,
         "release_99.0.yml",
-        "current-version: '99.0'\nprevious-version: '98.0'\nnext-version: '99.1'\nrelease-date: '2099-01-15'\nfreeze-date:\n",
+        "current-version: '99.0'\nprevious-version: '98.0'\nrelease-date: '2099-01-15'\nfreeze-date:\n",
     )
     with pytest.raises(ValueError, match="has no value"):
         load_release_config(tmp_path, Version("99.0"))
@@ -164,7 +174,7 @@ def test_load_release_config_version_mismatch(tmp_path, config_dir):
     _write_config(
         config_dir,
         "release_99.0.yml",
-        "current-version: '98.0'\nprevious-version: '97.0'\nnext-version: '99.0'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
+        "current-version: '98.0'\nprevious-version: '97.0'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
     )
     with pytest.raises(ValueError, match="does not match release-version argument"):
         load_release_config(tmp_path, Version("99.0"), release_config_path=config_dir / "release_99.0.yml")
@@ -175,6 +185,6 @@ def test_load_release_config_from_fixture():
     config = load_release_config(Path("."), Version("98.2"), release_config_path=config_path)
     assert config.current_version == Version("98.2")
     assert config.previous_version == Version("98.1")
-    assert config.next_version == Version("99.0")
+    assert config.next_version is None
     assert config.freeze_date == datetime.date(2099, 1, 1)
     assert config.release_date == datetime.date(2099, 1, 15)

--- a/tests/test_release_config.py
+++ b/tests/test_release_config.py
@@ -24,14 +24,14 @@ def test_load_release_config_default_path(tmp_path, config_dir):
     _write_config(
         config_dir,
         "release_98.2.yml",
-        "current-version: '98.2'\nprevious-version: '98.1'\nnext-version: '99.0'\nrelease-date: '2099-01-15'\n",
+        "current-version: '98.2'\nprevious-version: '98.1'\nnext-version: '99.0'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
     )
     config = load_release_config(tmp_path, Version("98.2"))
     assert config.current_version == Version("98.2")
     assert config.previous_version == Version("98.1")
     assert config.next_version == Version("99.0")
     assert config.release_date == datetime.date(2099, 1, 15)
-    assert config.freeze_date is None
+    assert config.freeze_date == datetime.date(2099, 1, 1)
     assert config.owner == "galaxyproject"
     assert config.repo == "galaxy"
 
@@ -71,33 +71,23 @@ def test_load_release_config_cli_only(tmp_path):
         previous_version=Version("98.0"),
         next_version=Version("99.1"),
         release_date=datetime.date(2099, 1, 15),
+        freeze_date=datetime.date(2099, 1, 1),
     )
     assert config.current_version == Version("99.0")
     assert config.previous_version == Version("98.0")
     assert config.next_version == Version("99.1")
     assert config.release_date == datetime.date(2099, 1, 15)
-    assert config.freeze_date is None
+    assert config.freeze_date == datetime.date(2099, 1, 1)
     assert config.owner == "galaxyproject"
     assert config.repo == "galaxy"
 
-
-def test_load_release_config_cli_with_freeze_date(tmp_path):
-    config = load_release_config(
-        tmp_path,
-        Version("99.0"),
-        previous_version=Version("98.0"),
-        next_version=Version("99.1"),
-        release_date=datetime.date(2099, 1, 15),
-        freeze_date=datetime.date(2099, 1, 1),
-    )
-    assert config.freeze_date == datetime.date(2099, 1, 1)
 
 
 def test_load_release_config_cli_overrides_yaml(tmp_path, config_dir):
     _write_config(
         config_dir,
         "release_98.2.yml",
-        "current-version: '98.2'\nprevious-version: '98.1'\nnext-version: '99.0'\nrelease-date: '2099-01-15'\n",
+        "current-version: '98.2'\nprevious-version: '98.1'\nnext-version: '99.0'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
     )
     config = load_release_config(
         tmp_path, Version("98.2"),
@@ -124,7 +114,7 @@ def test_load_release_config_null_required_field(tmp_path, config_dir):
     _write_config(
         config_dir,
         "release_99.0.yml",
-        "current-version: '99.0'\nprevious-version:\nnext-version: '99.1'\nrelease-date: '2099-01-15'\n",
+        "current-version: '99.0'\nprevious-version:\nnext-version: '99.1'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
     )
     with pytest.raises(ValueError, match="has no value"):
         load_release_config(tmp_path, Version("99.0"))
@@ -134,7 +124,7 @@ def test_load_release_config_invalid_version(tmp_path, config_dir):
     _write_config(
         config_dir,
         "release_99.0.yml",
-        "current-version: '!!!'\nprevious-version: '98.0'\nnext-version: '99.1'\nrelease-date: '2099-01-15'\n",
+        "current-version: '!!!'\nprevious-version: '98.0'\nnext-version: '99.1'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
     )
     with pytest.raises(ValueError, match="Invalid 'current-version'"):
         load_release_config(tmp_path, Version("99.0"))
@@ -144,7 +134,7 @@ def test_load_release_config_invalid_date(tmp_path, config_dir):
     _write_config(
         config_dir,
         "release_99.0.yml",
-        "current-version: '99.0'\nprevious-version: '98.0'\nnext-version: '99.1'\nrelease-date: 'not-a-date'\n",
+        "current-version: '99.0'\nprevious-version: '98.0'\nnext-version: '99.1'\nfreeze-date: '2099-01-01'\nrelease-date: 'not-a-date'\n",
     )
     with pytest.raises(ValueError, match="Invalid 'release-date'"):
         load_release_config(tmp_path, Version("99.0"))
@@ -156,7 +146,7 @@ def test_load_release_config_null_freeze_date(tmp_path, config_dir):
         "release_99.0.yml",
         "current-version: '99.0'\nprevious-version: '98.0'\nnext-version: '99.1'\nrelease-date: '2099-01-15'\nfreeze-date:\n",
     )
-    with pytest.raises(ValueError, match="'freeze-date' is present but has no value"):
+    with pytest.raises(ValueError, match="has no value"):
         load_release_config(tmp_path, Version("99.0"))
 
 
@@ -174,7 +164,7 @@ def test_load_release_config_version_mismatch(tmp_path, config_dir):
     _write_config(
         config_dir,
         "release_99.0.yml",
-        "current-version: '98.0'\nprevious-version: '97.0'\nnext-version: '99.0'\nrelease-date: '2099-01-15'\n",
+        "current-version: '98.0'\nprevious-version: '97.0'\nnext-version: '99.0'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
     )
     with pytest.raises(ValueError, match="does not match release-version argument"):
         load_release_config(tmp_path, Version("99.0"), release_config_path=config_dir / "release_99.0.yml")

--- a/tests/test_release_config.py
+++ b/tests/test_release_config.py
@@ -1,0 +1,190 @@
+import datetime
+from pathlib import Path
+
+import pytest
+from packaging.version import Version
+
+from galaxy_release_util.release_config import load_release_config
+
+
+@pytest.fixture
+def config_dir(tmp_path):
+    releases_dir = tmp_path / "doc" / "source" / "releases"
+    releases_dir.mkdir(parents=True)
+    return releases_dir
+
+
+def _write_config(config_dir, filename, content):
+    path = config_dir / filename
+    path.write_text(content)
+    return path
+
+
+def test_load_release_config_default_path(tmp_path, config_dir):
+    _write_config(
+        config_dir,
+        "release_98.2.yml",
+        "current-version: '98.2'\nprevious-version: '98.1'\nnext-version: '99.0'\nrelease-date: '2099-01-15'\n",
+    )
+    config = load_release_config(tmp_path, Version("98.2"))
+    assert config.current_version == Version("98.2")
+    assert config.previous_version == Version("98.1")
+    assert config.next_version == Version("99.0")
+    assert config.release_date == datetime.date(2099, 1, 15)
+    assert config.freeze_date is None
+    assert config.owner == "galaxyproject"
+    assert config.repo == "galaxy"
+
+
+def test_load_release_config_explicit_path(tmp_path, config_dir):
+    path = _write_config(
+        config_dir,
+        "custom.yml",
+        "current-version: '25.0'\nprevious-version: '24.2'\nnext-version: '25.1'\nrelease-date: '2025-07-01'\nfreeze-date: '2025-06-01'\nowner: myorg\nrepo: myrepo\n",
+    )
+    config = load_release_config(tmp_path, Version("25.0"), release_config_path=path)
+    assert config.current_version == Version("25.0")
+    assert config.previous_version == Version("24.2")
+    assert config.next_version == Version("25.1")
+    assert config.release_date == datetime.date(2025, 7, 1)
+    assert config.freeze_date == datetime.date(2025, 6, 1)
+    assert config.owner == "myorg"
+    assert config.repo == "myrepo"
+
+
+def test_load_release_config_explicit_path_missing(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_release_config(
+            tmp_path, Version("99.0"), release_config_path=tmp_path / "nonexistent.yml"
+        )
+
+
+def test_load_release_config_no_yaml_no_flags(tmp_path):
+    with pytest.raises(ValueError, match="missing required flag"):
+        load_release_config(tmp_path, Version("99.0"))
+
+
+def test_load_release_config_cli_only(tmp_path):
+    config = load_release_config(
+        tmp_path,
+        Version("99.0"),
+        previous_version=Version("98.0"),
+        next_version=Version("99.1"),
+        release_date=datetime.date(2099, 1, 15),
+    )
+    assert config.current_version == Version("99.0")
+    assert config.previous_version == Version("98.0")
+    assert config.next_version == Version("99.1")
+    assert config.release_date == datetime.date(2099, 1, 15)
+    assert config.freeze_date is None
+    assert config.owner == "galaxyproject"
+    assert config.repo == "galaxy"
+
+
+def test_load_release_config_cli_with_freeze_date(tmp_path):
+    config = load_release_config(
+        tmp_path,
+        Version("99.0"),
+        previous_version=Version("98.0"),
+        next_version=Version("99.1"),
+        release_date=datetime.date(2099, 1, 15),
+        freeze_date=datetime.date(2099, 1, 1),
+    )
+    assert config.freeze_date == datetime.date(2099, 1, 1)
+
+
+def test_load_release_config_cli_overrides_yaml(tmp_path, config_dir):
+    _write_config(
+        config_dir,
+        "release_98.2.yml",
+        "current-version: '98.2'\nprevious-version: '98.1'\nnext-version: '99.0'\nrelease-date: '2099-01-15'\n",
+    )
+    config = load_release_config(
+        tmp_path, Version("98.2"),
+        next_version=Version("99.5"),
+        release_date=datetime.date(2099, 6, 1),
+    )
+    assert config.next_version == Version("99.5")
+    assert config.release_date == datetime.date(2099, 6, 1)
+    # Non-overridden values from YAML
+    assert config.previous_version == Version("98.1")
+
+
+def test_load_release_config_missing_field(tmp_path, config_dir):
+    _write_config(
+        config_dir,
+        "release_99.0.yml",
+        "current-version: '99.0'\n",
+    )
+    with pytest.raises(ValueError, match="Missing required field"):
+        load_release_config(tmp_path, Version("99.0"))
+
+
+def test_load_release_config_null_required_field(tmp_path, config_dir):
+    _write_config(
+        config_dir,
+        "release_99.0.yml",
+        "current-version: '99.0'\nprevious-version:\nnext-version: '99.1'\nrelease-date: '2099-01-15'\n",
+    )
+    with pytest.raises(ValueError, match="has no value"):
+        load_release_config(tmp_path, Version("99.0"))
+
+
+def test_load_release_config_invalid_version(tmp_path, config_dir):
+    _write_config(
+        config_dir,
+        "release_99.0.yml",
+        "current-version: '!!!'\nprevious-version: '98.0'\nnext-version: '99.1'\nrelease-date: '2099-01-15'\n",
+    )
+    with pytest.raises(ValueError, match="Invalid 'current-version'"):
+        load_release_config(tmp_path, Version("99.0"))
+
+
+def test_load_release_config_invalid_date(tmp_path, config_dir):
+    _write_config(
+        config_dir,
+        "release_99.0.yml",
+        "current-version: '99.0'\nprevious-version: '98.0'\nnext-version: '99.1'\nrelease-date: 'not-a-date'\n",
+    )
+    with pytest.raises(ValueError, match="Invalid 'release-date'"):
+        load_release_config(tmp_path, Version("99.0"))
+
+
+def test_load_release_config_null_freeze_date(tmp_path, config_dir):
+    _write_config(
+        config_dir,
+        "release_99.0.yml",
+        "current-version: '99.0'\nprevious-version: '98.0'\nnext-version: '99.1'\nrelease-date: '2099-01-15'\nfreeze-date:\n",
+    )
+    with pytest.raises(ValueError, match="'freeze-date' is present but has no value"):
+        load_release_config(tmp_path, Version("99.0"))
+
+
+def test_load_release_config_not_a_mapping(tmp_path, config_dir):
+    _write_config(
+        config_dir,
+        "release_99.0.yml",
+        "- item1\n- item2\n",
+    )
+    with pytest.raises(ValueError, match="must be a YAML mapping"):
+        load_release_config(tmp_path, Version("99.0"))
+
+
+def test_load_release_config_version_mismatch(tmp_path, config_dir):
+    _write_config(
+        config_dir,
+        "release_99.0.yml",
+        "current-version: '98.0'\nprevious-version: '97.0'\nnext-version: '99.0'\nrelease-date: '2099-01-15'\n",
+    )
+    with pytest.raises(ValueError, match="does not match release-version argument"):
+        load_release_config(tmp_path, Version("99.0"), release_config_path=config_dir / "release_99.0.yml")
+
+
+def test_load_release_config_from_fixture():
+    config_path = Path("tests/test_data/release_98.2.yml")
+    config = load_release_config(Path("."), Version("98.2"), release_config_path=config_path)
+    assert config.current_version == Version("98.2")
+    assert config.previous_version == Version("98.1")
+    assert config.next_version == Version("99.0")
+    assert config.freeze_date == datetime.date(2099, 1, 1)
+    assert config.release_date == datetime.date(2099, 1, 15)

--- a/tests/test_release_config.py
+++ b/tests/test_release_config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from packaging.version import Version
 
-from galaxy_release_util.release_config import load_release_config
+from galaxy_release_util.release_config import load_release_config, load_repo_owner
 
 
 @pytest.fixture
@@ -188,3 +188,53 @@ def test_load_release_config_from_fixture():
     assert config.next_version is None
     assert config.freeze_date == datetime.date(2099, 1, 1)
     assert config.release_date == datetime.date(2099, 1, 15)
+
+
+def test_load_repo_owner_from_config(config_dir, tmp_path):
+    config_content = (
+        "current-version: '98.2'\n"
+        "previous-version: '98.1'\n"
+        "release-date: '2099-01-15'\n"
+        "freeze-date: '2099-01-01'\n"
+        "owner: 'myorg'\n"
+        "repo: 'mygalaxy'\n"
+    )
+    (config_dir / "release_98.2.yml").write_text(config_content)
+    owner, repo = load_repo_owner(tmp_path, Version("98.2"))
+    assert owner == "myorg"
+    assert repo == "mygalaxy"
+
+
+def test_load_repo_owner_point_release(config_dir, tmp_path):
+    """Point release version 98.2.1 should find config for 98.2."""
+    config_content = (
+        "current-version: '98.2'\n"
+        "previous-version: '98.1'\n"
+        "release-date: '2099-01-15'\n"
+        "freeze-date: '2099-01-01'\n"
+        "owner: 'myorg'\n"
+        "repo: 'mygalaxy'\n"
+    )
+    (config_dir / "release_98.2.yml").write_text(config_content)
+    owner, repo = load_repo_owner(tmp_path, Version("98.2.1"))
+    assert owner == "myorg"
+    assert repo == "mygalaxy"
+
+
+def test_load_repo_owner_defaults_when_no_config(tmp_path):
+    owner, repo = load_repo_owner(tmp_path, Version("99.0"))
+    assert owner == "galaxyproject"
+    assert repo == "galaxy"
+
+
+def test_load_repo_owner_defaults_when_no_owner_in_config(config_dir, tmp_path):
+    config_content = (
+        "current-version: '98.2'\n"
+        "previous-version: '98.1'\n"
+        "release-date: '2099-01-15'\n"
+        "freeze-date: '2099-01-01'\n"
+    )
+    (config_dir / "release_98.2.yml").write_text(config_content)
+    owner, repo = load_repo_owner(tmp_path, Version("98.2"))
+    assert owner == "galaxyproject"
+    assert repo == "galaxy"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,21 @@
+import pytest
+
+from galaxy_release_util.util import escape_rst_inline
+
+
+@pytest.mark.parametrize(
+    "input_text, expected",
+    [
+        ("simple title", "simple title"),
+        ("has *bold* text", r"has \*bold\* text"),
+        ("has `code` here", r"has \`code\` here"),
+        ("pipe|separated", r"pipe\|separated"),
+        ("backslash\\present", r"backslash\\present"),
+        ("mixed *bold* and `code`", r"mixed \*bold\* and \`code\`"),
+        ("no special chars", "no special chars"),
+        ("", ""),
+        ("***triple***", r"\*\*\*triple\*\*\*"),
+    ],
+)
+def test_escape_rst_inline(input_text, expected):
+    assert escape_rst_inline(input_text) == expected


### PR DESCRIPTION
This PR adds a YAML based release configuration file at doc source releases release version yml to make release metadata explicit, versioned, and shareable, while **retaining and extending the existing explicit CLI flags** for previous version, next version, freeze date, and release date. The YAML is optional by default, required only when explicitly passed, and CLI flags cleanly override YAML values so the tool can still be used without a config file. Release configuration resolution prefers the YAML when present, applies any CLI overrides, and hard fails on missing files, invalid structure, missing or null required fields, malformed versions or dates, or mismatches between the YAML and the positional release version, with only owner and repo retaining defaults. The change removes _get_next_release_version and deletes dead version derivation code paths, adds optional owner and repo fields to support private repository workflows, and threads them consistently through release issue generation, changelog creation, blocking checks, and PR resolution. Dry run handling is corrected and expanded across all commands, import time GitHub client side effects are removed, long standing parsing and precedence bugs are fixed, hardcoded project constants are replaced with metadata helpers, and TASKS.md is updated to document the new YAML first release workflow.