### PR TITLE
Add snapshot utility?

### DIFF
--- a/galaxy_release_util/cli/release_util.py
+++ b/galaxy_release_util/cli/release_util.py
@@ -2,8 +2,9 @@ import click
 
 from ..bootstrap_history import cli as bootstrap_cli
 from ..point_release import cli as point_release_cli
+from ..snapshot_release import cli as snapshot_cli
 
 cli = click.CommandCollection(
-    sources=[bootstrap_cli, point_release_cli],
+    sources=[bootstrap_cli, point_release_cli, snapshot_cli],
     help="Perform various tasks around creating Galaxy releases and point releases",
 )

--- a/galaxy_release_util/point_release.py
+++ b/galaxy_release_util/point_release.py
@@ -848,10 +848,13 @@ def stage_changes_and_commit(
     subprocess.run(["git", "commit", "-m", commit_message], cwd=galaxy_root)
 
 
-def create_tag(galaxy_root: Path, release_tag: str, no_confirm: bool) -> None:
+def create_tag(galaxy_root: Path, release_tag: str, no_confirm: bool, message: Optional[str] = None) -> None:
     if not no_confirm:
         click.confirm(f"Create git tag '{release_tag}'?", abort=True)
-    subprocess.run(["git", "tag", release_tag], cwd=galaxy_root)
+    if message:
+        subprocess.run(["git", "tag", "-a", "-m", message, release_tag], cwd=galaxy_root)
+    else:
+        subprocess.run(["git", "tag", release_tag], cwd=galaxy_root)
 
 
 def merge_changes_into_newer_branches(

--- a/galaxy_release_util/snapshot_release.py
+++ b/galaxy_release_util/snapshot_release.py
@@ -19,6 +19,7 @@ from .metadata import get_repo_name
 from .point_release import (
     ChangelogItem,
     Package,
+    build_package,
     bump_package_version,
     commits_to_prs,
     create_tag,
@@ -203,14 +204,19 @@ def create_release_snapshot(
 
     update_client_version(galaxy_root, snapshot_version, modified_paths)
 
-    # 12. Commit
+    # 12. Build packages (validation only — artifacts are discarded)
+    #     This runs before commit/tag so packaging failures abort the snapshot
+    #     without leaving any trace in git history.
+    _build_packages_or_abort(packages)
+
+    # 13. Commit
     commit_message = f"Snapshot release {snapshot_version}\n\n{SNAPSHOT_TAG_MESSAGE}"
     stage_changes_and_commit(galaxy_root, snapshot_version, modified_paths, commit_message, no_confirm=True)
 
-    # 13. Annotated tag
+    # 14. Annotated tag
     create_tag(galaxy_root, snapshot_tag, no_confirm=True, message=SNAPSHOT_TAG_MESSAGE)
 
-    # 14. Push tag only
+    # 15. Push tag only
     click.echo(f"Pushing {snapshot_tag} to {push_remote}")
     try:
         subprocess.run(
@@ -221,6 +227,24 @@ def create_release_snapshot(
         raise
 
     click.echo(f"Snapshot release {snapshot_version} created and pushed as {snapshot_tag}")
+
+
+def _build_packages_or_abort(packages: List[Package]) -> None:
+    """Build each package to validate the packaging path.
+
+    Builds are validation-only — artifacts are not uploaded or used.
+    If any package fails to build, abort before any commit or tag is created
+    so the snapshot does not produce a misleading release artifact.
+    """
+    click.echo(f"Building {len(packages)} package(s) to validate packaging path")
+    for package in packages:
+        try:
+            build_package(package)
+        except subprocess.CalledProcessError as e:
+            raise click.ClickException(
+                f"Package '{package.name}' failed to build: {e}. "
+                "Aborting snapshot — no commit or tag has been created."
+            ) from e
 
 
 def _load_packages_without_baseline(galaxy_root: Path) -> List[Package]:

--- a/galaxy_release_util/snapshot_release.py
+++ b/galaxy_release_util/snapshot_release.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 import subprocess
 from pathlib import Path
 from typing import (
@@ -44,22 +43,33 @@ CANONICAL_HTTPS = f"https://github.com/{CANONICAL_OWNER}/{CANONICAL_REPO}.git"
 
 SNAPSHOT_TAG_PREFIX = "snapshot-v"
 SNAPSHOT_TAG_MESSAGE = "Validation snapshot for release process exercise on fork, derived from galaxyproject/galaxy dev"
-INITIAL_SNAPSHOT_TEXT = "Initial snapshot — no prior baseline"
+INITIAL_SNAPSHOT_TEXT = "Initial snapshot - no prior baseline"
 
 
 def find_canonical_upstream(galaxy_root: Path) -> str:
-    """Find the canonical galaxyproject/galaxy remote URL from local git remotes."""
+    """Find the canonical galaxyproject/galaxy remote fetch URL from local git remotes.
+
+    Enumerates configured remotes by name and checks each remote's fetch URL
+    against the canonical identity. Returns the first match, or the HTTPS
+    fallback if no remote points to canonical.
+    """
     result = subprocess.run(
-        ["git", "remote", "-v"], cwd=galaxy_root, capture_output=True, text=True,
+        ["git", "remote"], cwd=galaxy_root, capture_output=True, text=True,
     )
     result.check_returncode()
-    canonical_pattern = re.compile(r"galaxyproject[/:]galaxy(?:\.git)?(?:\s|$)", re.IGNORECASE)
-    for line in result.stdout.splitlines():
-        parts = line.split()
-        if len(parts) >= 2 and "(fetch)" in line:
-            url = parts[1]
-            if canonical_pattern.search(url):
-                return url
+    for remote_name in result.stdout.splitlines():
+        remote_name = remote_name.strip()
+        if not remote_name:
+            continue
+        fetch_url_result = subprocess.run(
+            ["git", "remote", "get-url", remote_name],
+            cwd=galaxy_root, capture_output=True, text=True,
+        )
+        if fetch_url_result.returncode != 0:
+            continue
+        fetch_url = fetch_url_result.stdout.strip()
+        if _url_points_to_canonical(fetch_url):
+            return fetch_url
     return CANONICAL_HTTPS
 
 
@@ -73,6 +83,44 @@ def find_last_snapshot_tag(galaxy_root: Path, major_minor: str) -> Optional[str]
     result.check_returncode()
     tags = result.stdout.strip().splitlines()
     return tags[0] if tags else None
+
+
+def _resolve_push_remote_url(galaxy_root: Path, push_remote: str) -> str:
+    """Resolve push_remote to the concrete URL that `git push` would actually target.
+
+    If push_remote is a local git remote name (e.g. 'origin', 'upstream'),
+    returns the remote's push URL, which may differ from its fetch URL when
+    a separate pushurl is configured. Otherwise, assumes push_remote is already
+    a URL and returns it unchanged.
+
+    Using the push URL (not the fetch URL) is a safety requirement: we must
+    validate the same target that `git push` will use.
+    """
+    result = subprocess.run(
+        ["git", "remote", "get-url", "--push", push_remote],
+        cwd=galaxy_root, capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        return result.stdout.strip()
+    # Not a known remote name - assume it's already a URL
+    return push_remote
+
+
+def _url_points_to_canonical(url: str) -> bool:
+    """Check whether a git URL resolves to the canonical galaxyproject/galaxy repo.
+
+    Handles SSH (git@github.com:galaxyproject/galaxy[.git]),
+    HTTPS (https://github.com/galaxyproject/galaxy[.git]),
+    case variations, and trailing slashes.
+    """
+    normalized = url.strip().lower().rstrip("/")
+    if normalized.endswith(".git"):
+        normalized = normalized[:-4]
+    # Match both SSH and HTTPS forms ending in galaxyproject/galaxy
+    return (
+        normalized.endswith(f"/{CANONICAL_OWNER}/{CANONICAL_REPO}")
+        or normalized.endswith(f":{CANONICAL_OWNER}/{CANONICAL_REPO}")
+    )
 
 
 def _tag_exists_locally(galaxy_root: Path, tag: str) -> bool:
@@ -167,14 +215,28 @@ def create_release_snapshot(
     if _tag_exists_locally(galaxy_root, snapshot_tag):
         raise click.ClickException(f"Tag '{snapshot_tag}' already exists locally. A snapshot was already created today.")
 
-    # 7. Compute push remote and refuse if tag already exists on remote
+    # 7. Compute push remote
     if push_remote is None:
         push_remote = f"git@github.com:{get_repo_name(owner, repo)}.git"
 
-    click.echo(f"Snapshot: {snapshot_version} -> {push_remote}")
+    # Resolve to a concrete URL (handle remote names like 'origin', 'upstream')
+    # and hard-refuse if it points to canonical galaxyproject/galaxy.
+    # This is the enforced safety boundary: no push operation can target canonical.
+    resolved_push_url = _resolve_push_remote_url(galaxy_root, push_remote)
+    if _url_points_to_canonical(resolved_push_url):
+        raise click.ClickException(
+            f"Push target '{push_remote}' resolves to the canonical "
+            f"galaxyproject/galaxy repository ({resolved_push_url}). "
+            "Snapshot releases must never push to the canonical repository. "
+            "Specify a fork via --push-remote or the release config YAML."
+        )
 
-    if _tag_exists_on_remote(galaxy_root, push_remote, snapshot_tag):
-        raise click.ClickException(f"Tag '{snapshot_tag}' already exists on remote {push_remote}.")
+    click.echo(f"Snapshot: {snapshot_version} -> {resolved_push_url}")
+
+    # From this point on, use resolved_push_url everywhere, never the original token.
+    # This guarantees the validated target and the actual push target are the same URL.
+    if _tag_exists_on_remote(galaxy_root, resolved_push_url, snapshot_tag):
+        raise click.ClickException(f"Tag '{snapshot_tag}' already exists on remote {resolved_push_url}.")
 
     # 8. Verify HEAD matches canonical upstream dev
     canonical_url = find_canonical_upstream(galaxy_root)
@@ -204,7 +266,7 @@ def create_release_snapshot(
 
     update_client_version(galaxy_root, snapshot_version, modified_paths)
 
-    # 12. Build packages (validation only — artifacts are discarded)
+    # 12. Build packages (validation only, artifacts are discarded)
     #     This runs before commit/tag so packaging failures abort the snapshot
     #     without leaving any trace in git history.
     _build_packages_or_abort(packages)
@@ -216,14 +278,16 @@ def create_release_snapshot(
     # 14. Annotated tag
     create_tag(galaxy_root, snapshot_tag, no_confirm=True, message=SNAPSHOT_TAG_MESSAGE)
 
-    # 15. Push tag only
-    click.echo(f"Pushing {snapshot_tag} to {push_remote}")
+    # 15. Push tag only, using the resolved URL rather than the original token.
+    #     This prevents git from dispatching to a different target than the
+    #     one that was safety-validated.
+    click.echo(f"Pushing {snapshot_tag} to {resolved_push_url}")
     try:
         subprocess.run(
-            ["git", "push", push_remote, snapshot_tag], cwd=galaxy_root,
+            ["git", "push", resolved_push_url, snapshot_tag], cwd=galaxy_root,
         ).check_returncode()
     except subprocess.CalledProcessError:
-        click.echo(f"\nPush failed. To complete manually:\n  git push {push_remote} {snapshot_tag}")
+        click.echo(f"\nPush failed. To complete manually:\n  git push {resolved_push_url} {snapshot_tag}")
         raise
 
     click.echo(f"Snapshot release {snapshot_version} created and pushed as {snapshot_tag}")
@@ -232,7 +296,7 @@ def create_release_snapshot(
 def _build_packages_or_abort(packages: List[Package]) -> None:
     """Build each package to validate the packaging path.
 
-    Builds are validation-only — artifacts are not uploaded or used.
+    Builds are validation-only: artifacts are not uploaded or used.
     If any package fails to build, abort before any commit or tag is created
     so the snapshot does not produce a misleading release artifact.
     """
@@ -243,7 +307,7 @@ def _build_packages_or_abort(packages: List[Package]) -> None:
         except subprocess.CalledProcessError as e:
             raise click.ClickException(
                 f"Package '{package.name}' failed to build: {e}. "
-                "Aborting snapshot — no commit or tag has been created."
+                "Aborting snapshot: no commit or tag has been created."
             ) from e
 
 

--- a/galaxy_release_util/snapshot_release.py
+++ b/galaxy_release_util/snapshot_release.py
@@ -1,0 +1,255 @@
+import datetime
+import re
+import subprocess
+from pathlib import Path
+from typing import (
+    List,
+    Optional,
+)
+
+import click
+from packaging.version import Version
+
+from .cli.options import (
+    galaxy_root_option,
+    group_options,
+    release_config_option,
+)
+from .metadata import get_repo_name
+from .point_release import (
+    ChangelogItem,
+    Package,
+    bump_package_version,
+    commits_to_prs,
+    create_tag,
+    get_current_branch,
+    get_root_version,
+    get_sorted_package_paths,
+    is_git_clean,
+    load_packages,
+    read_package,
+    set_root_version,
+    stage_changes_and_commit,
+    update_client_version,
+    update_packages,
+    version_filepath,
+)
+from .release_config import load_repo_owner
+from .util import verify_galaxy_root
+
+CANONICAL_OWNER = "galaxyproject"
+CANONICAL_REPO = "galaxy"
+CANONICAL_HTTPS = f"https://github.com/{CANONICAL_OWNER}/{CANONICAL_REPO}.git"
+
+SNAPSHOT_TAG_PREFIX = "snapshot-v"
+SNAPSHOT_TAG_MESSAGE = "Validation snapshot for release process exercise on fork, derived from galaxyproject/galaxy dev"
+INITIAL_SNAPSHOT_TEXT = "Initial snapshot — no prior baseline"
+
+
+def find_canonical_upstream(galaxy_root: Path) -> str:
+    """Find the canonical galaxyproject/galaxy remote URL from local git remotes."""
+    result = subprocess.run(
+        ["git", "remote", "-v"], cwd=galaxy_root, capture_output=True, text=True,
+    )
+    result.check_returncode()
+    canonical_pattern = re.compile(r"galaxyproject[/:]galaxy(?:\.git)?(?:\s|$)", re.IGNORECASE)
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and "(fetch)" in line:
+            url = parts[1]
+            if canonical_pattern.search(url):
+                return url
+    return CANONICAL_HTTPS
+
+
+def find_last_snapshot_tag(galaxy_root: Path, major_minor: str) -> Optional[str]:
+    """Find the most recent snapshot tag reachable from HEAD for the given major.minor."""
+    result = subprocess.run(
+        ["git", "tag", "--list", f"{SNAPSHOT_TAG_PREFIX}{major_minor}.*",
+         "--merged", "HEAD", "--sort=-v:refname"],
+        cwd=galaxy_root, capture_output=True, text=True,
+    )
+    result.check_returncode()
+    tags = result.stdout.strip().splitlines()
+    return tags[0] if tags else None
+
+
+def _tag_exists_locally(galaxy_root: Path, tag: str) -> bool:
+    result = subprocess.run(
+        ["git", "tag", "--list", tag], cwd=galaxy_root, capture_output=True, text=True,
+    )
+    return bool(result.stdout.strip())
+
+
+def _tag_exists_on_remote(galaxy_root: Path, remote_url: str, tag: str) -> bool:
+    result = subprocess.run(
+        ["git", "ls-remote", remote_url, f"refs/tags/{tag}"],
+        cwd=galaxy_root, capture_output=True, text=True,
+    )
+    return bool(result.stdout.strip())
+
+
+def _verify_upstream_alignment(galaxy_root: Path, canonical_url: str) -> None:
+    """Verify HEAD matches canonical upstream dev."""
+    result = subprocess.run(
+        ["git", "ls-remote", canonical_url, "refs/heads/dev"],
+        cwd=galaxy_root, capture_output=True, text=True,
+    )
+    result.check_returncode()
+    if not result.stdout.strip():
+        raise click.ClickException(
+            f"Could not read refs/heads/dev from canonical upstream {canonical_url}"
+        )
+    remote_hash = result.stdout.split("\t")[0]
+    local_result = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=galaxy_root, capture_output=True, text=True,
+    )
+    local_result.check_returncode()
+    local_hash = local_result.stdout.strip()
+    if remote_hash != local_hash:
+        raise click.ClickException(
+            f"HEAD ({local_hash[:12]}) does not match canonical upstream dev ({remote_hash[:12]}). "
+            f"Sync your fork to {canonical_url} before creating a snapshot."
+        )
+
+
+@click.group(help="Subcommands for creating release snapshots on private forks")
+def cli():
+    pass
+
+
+@cli.command("create-release-snapshot", help="Create a date-based release snapshot for a private Galaxy fork")
+@group_options(
+    galaxy_root_option,
+    release_config_option,
+)
+@click.option(
+    "--push-remote",
+    type=str,
+    default=None,
+    help="Git remote URL to push the snapshot tag to. Default: derived from config owner/repo.",
+)
+def create_release_snapshot(
+    galaxy_root: Path,
+    release_config: Optional[Path],
+    push_remote: Optional[str],
+):
+    # 1. Validate galaxy root
+    verify_galaxy_root(galaxy_root)
+
+    # 2. Refuse if dirty tree (cheap local check, before any network call)
+    if not is_git_clean(galaxy_root):
+        raise click.ClickException("Working tree is not clean. Commit or stash changes before creating a snapshot.")
+
+    # 3. Refuse if not on dev branch
+    branch = get_current_branch(galaxy_root)
+    if branch != "dev":
+        raise click.ClickException(f"Snapshot releases must be created on the 'dev' branch, currently on '{branch}'.")
+
+    # 4. Compute root version once, reuse throughout
+    root_version = get_root_version(galaxy_root)
+    major_minor = f"{root_version.major}.{root_version.minor}"
+
+    # 5. Load owner/repo and refuse if targeting canonical repo
+    owner, repo = load_repo_owner(galaxy_root, root_version, release_config)
+    if owner == CANONICAL_OWNER and repo == CANONICAL_REPO:
+        raise click.ClickException(
+            "Snapshot releases must not target the official galaxyproject/galaxy repository. "
+            "Set owner/repo in your release config YAML to point to your fork."
+        )
+
+    # 6. Compute snapshot version and refuse if tag already exists locally
+    date_str = datetime.date.today().strftime("%Y%m%d")
+    snapshot_version = Version(f"{major_minor}.dev{date_str}")
+    snapshot_tag = f"{SNAPSHOT_TAG_PREFIX}{snapshot_version}"
+
+    if _tag_exists_locally(galaxy_root, snapshot_tag):
+        raise click.ClickException(f"Tag '{snapshot_tag}' already exists locally. A snapshot was already created today.")
+
+    # 7. Compute push remote and refuse if tag already exists on remote
+    if push_remote is None:
+        push_remote = f"git@github.com:{get_repo_name(owner, repo)}.git"
+
+    click.echo(f"Snapshot: {snapshot_version} -> {push_remote}")
+
+    if _tag_exists_on_remote(galaxy_root, push_remote, snapshot_tag):
+        raise click.ClickException(f"Tag '{snapshot_tag}' already exists on remote {push_remote}.")
+
+    # 8. Verify HEAD matches canonical upstream dev
+    canonical_url = find_canonical_upstream(galaxy_root)
+    _verify_upstream_alignment(galaxy_root, canonical_url)
+
+    # 9. Find previous snapshot tag for changelog baseline
+    last_tag = find_last_snapshot_tag(galaxy_root, major_minor)
+
+    # 10. Load packages and resolve PRs
+    if last_tag:
+        click.echo(f"Previous snapshot: {last_tag}")
+        packages = load_packages(galaxy_root, [], last_tag)
+        commits_to_prs(packages, CANONICAL_OWNER, CANONICAL_REPO)
+    else:
+        click.echo("First snapshot - no prior baseline")
+        packages = _load_packages_without_baseline(galaxy_root)
+
+    # 11. Bump versions and generate changelogs
+    version_py = version_filepath(galaxy_root)
+    set_root_version(version_py, snapshot_version)
+    modified_paths: List[Path] = [version_py]
+
+    if last_tag:
+        update_packages(packages, snapshot_version, modified_paths)
+    else:
+        _apply_initial_snapshot_changelog(packages, snapshot_version, modified_paths)
+
+    update_client_version(galaxy_root, snapshot_version, modified_paths)
+
+    # 12. Commit
+    commit_message = f"Snapshot release {snapshot_version}\n\n{SNAPSHOT_TAG_MESSAGE}"
+    stage_changes_and_commit(galaxy_root, snapshot_version, modified_paths, commit_message, no_confirm=True)
+
+    # 13. Annotated tag
+    create_tag(galaxy_root, snapshot_tag, no_confirm=True, message=SNAPSHOT_TAG_MESSAGE)
+
+    # 14. Push tag only
+    click.echo(f"Pushing {snapshot_tag} to {push_remote}")
+    try:
+        subprocess.run(
+            ["git", "push", push_remote, snapshot_tag], cwd=galaxy_root,
+        ).check_returncode()
+    except subprocess.CalledProcessError:
+        click.echo(f"\nPush failed. To complete manually:\n  git push {push_remote} {snapshot_tag}")
+        raise
+
+    click.echo(f"Snapshot release {snapshot_version} created and pushed as {snapshot_tag}")
+
+
+def _load_packages_without_baseline(galaxy_root: Path) -> List[Package]:
+    """Load packages for first snapshot: no commit range, no PR resolution.
+
+    Reads package metadata (setup.cfg, HISTORY.rst) without computing
+    a commit diff. Packages will have empty commit and PR sets.
+    """
+    packages = []
+    for package_path in get_sorted_package_paths(galaxy_root):
+        package = read_package(package_path)
+        packages.append(package)
+    return packages
+
+
+def _apply_initial_snapshot_changelog(packages: List[Package], snapshot_version: Version, modified_paths: List[Path]) -> None:
+    """Apply explicit initial snapshot changelog to all packages.
+
+    Used for the first snapshot when no prior baseline exists.
+    Bypasses the normal PR-based changelog generation.
+    """
+    today = datetime.date.today().isoformat()
+    for package in packages:
+        bump_package_version(package, snapshot_version)
+        changelog_item = ChangelogItem(
+            version=snapshot_version,
+            changes=[f"* {INITIAL_SNAPSHOT_TEXT}"],
+            date=today,
+        )
+        package.package_history.insert(0, changelog_item)
+        package.write_history()
+        modified_paths.extend(package.modified_paths)

--- a/tests/test_snapshot_release.py
+++ b/tests/test_snapshot_release.py
@@ -1,0 +1,224 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from packaging.version import Version
+
+from galaxy_release_util.snapshot_release import (
+    CANONICAL_OWNER,
+    CANONICAL_REPO,
+    SNAPSHOT_TAG_PREFIX,
+    find_canonical_upstream,
+    find_last_snapshot_tag,
+)
+
+
+class TestFindCanonicalUpstream:
+    def _mock_remotes(self, output):
+        return patch(
+            "galaxy_release_util.snapshot_release.subprocess.run",
+            return_value=MagicMock(
+                stdout=output, returncode=0, check_returncode=lambda: None,
+            ),
+        )
+
+    def test_ssh_remote(self):
+        remotes = "origin\tgit@github.com:guerler/galaxy.git (fetch)\nupstream\tgit@github.com:galaxyproject/galaxy.git (fetch)\n"
+        with self._mock_remotes(remotes):
+            assert find_canonical_upstream(Path("/fake")) == "git@github.com:galaxyproject/galaxy.git"
+
+    def test_https_remote(self):
+        remotes = "upstream\thttps://github.com/galaxyproject/galaxy.git (fetch)\n"
+        with self._mock_remotes(remotes):
+            assert find_canonical_upstream(Path("/fake")) == "https://github.com/galaxyproject/galaxy.git"
+
+    def test_https_no_git_suffix(self):
+        remotes = "upstream\thttps://github.com/galaxyproject/galaxy (fetch)\n"
+        with self._mock_remotes(remotes):
+            assert find_canonical_upstream(Path("/fake")) == "https://github.com/galaxyproject/galaxy"
+
+    def test_case_insensitive(self):
+        remotes = "upstream\thttps://github.com/GalaxyProject/Galaxy.git (fetch)\n"
+        with self._mock_remotes(remotes):
+            assert find_canonical_upstream(Path("/fake")) == "https://github.com/GalaxyProject/Galaxy.git"
+
+    def test_no_match_returns_fallback(self):
+        remotes = "origin\tgit@github.com:guerler/galaxy.git (fetch)\n"
+        with self._mock_remotes(remotes):
+            url = find_canonical_upstream(Path("/fake"))
+            assert url == "https://github.com/galaxyproject/galaxy.git"
+
+    def test_ignores_push_lines(self):
+        remotes = (
+            "upstream\tgit@github.com:guerler/galaxy.git (fetch)\n"
+            "upstream\tgit@github.com:galaxyproject/galaxy.git (push)\n"
+        )
+        with self._mock_remotes(remotes):
+            # Should not match the push line, should fall back
+            url = find_canonical_upstream(Path("/fake"))
+            assert url == "https://github.com/galaxyproject/galaxy.git"
+
+
+class TestFindLastSnapshotTag:
+    def _mock_tags(self, output):
+        return patch(
+            "galaxy_release_util.snapshot_release.subprocess.run",
+            return_value=MagicMock(
+                stdout=output, returncode=0, check_returncode=lambda: None,
+            ),
+        )
+
+    def test_finds_latest(self):
+        tags = "snapshot-v25.1.dev20260411\nsnapshot-v25.1.dev20260301\n"
+        with self._mock_tags(tags):
+            result = find_last_snapshot_tag(Path("/fake"), "25.1")
+            assert result == "snapshot-v25.1.dev20260411"
+
+    def test_returns_none_when_empty(self):
+        with self._mock_tags(""):
+            result = find_last_snapshot_tag(Path("/fake"), "25.1")
+            assert result is None
+
+    def test_ignores_official_tags(self):
+        """Official v* tags should never appear because the --list pattern only matches snapshot-v*."""
+        # This test verifies the git command uses the correct prefix pattern.
+        # The mock returns only what git would return for "snapshot-v25.1.*"
+        with self._mock_tags("") as mock_run:
+            find_last_snapshot_tag(Path("/fake"), "25.1")
+            call_args = mock_run.call_args[0][0]
+            # Verify the --list pattern includes the snapshot prefix
+            assert f"{SNAPSHOT_TAG_PREFIX}25.1.*" in call_args
+            assert "--merged" in call_args
+            assert "HEAD" in call_args
+
+
+class TestVersionComputation:
+    def test_from_point_release(self):
+        root = Version("25.1.2")
+        major_minor = f"{root.major}.{root.minor}"
+        date_str = "20260411"
+        snapshot = Version(f"{major_minor}.dev{date_str}")
+        assert str(snapshot) == "25.1.dev20260411"
+        assert snapshot < Version("25.1.0")
+
+    def test_from_dev_release(self):
+        root = Version("26.0.dev0")
+        major_minor = f"{root.major}.{root.minor}"
+        date_str = "20260411"
+        snapshot = Version(f"{major_minor}.dev{date_str}")
+        assert str(snapshot) == "26.0.dev20260411"
+
+    def test_from_major_minor_only(self):
+        root = Version("26.0")
+        major_minor = f"{root.major}.{root.minor}"
+        date_str = "20260411"
+        snapshot = Version(f"{major_minor}.dev{date_str}")
+        assert str(snapshot) == "26.0.dev20260411"
+
+    def test_sorts_before_official(self):
+        snapshot = Version("25.1.dev20260411")
+        official = Version("25.1.0")
+        assert snapshot < official
+
+
+class TestSafetyChecks:
+    """Test safety checks via the CLI command."""
+
+    def test_refuse_galaxyproject_owner(self, monkeypatch, tmp_path):
+        from click.testing import CliRunner
+        from galaxy_release_util.snapshot_release import cli
+
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.verify_galaxy_root", lambda x: None)
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.is_git_clean", lambda x: True)
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.get_current_branch", lambda x: "dev")
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.get_root_version", lambda x: Version("25.1.2"))
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release.load_repo_owner",
+            lambda *a, **kw: (CANONICAL_OWNER, CANONICAL_REPO),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["create-release-snapshot", "--galaxy-root", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "must not target the official galaxyproject/galaxy" in result.output
+
+    def test_refuse_non_dev_branch(self, monkeypatch, tmp_path):
+        from click.testing import CliRunner
+        from galaxy_release_util.snapshot_release import cli
+
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.verify_galaxy_root", lambda x: None)
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.is_git_clean", lambda x: True)
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.get_current_branch", lambda x: "release_25.1")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["create-release-snapshot", "--galaxy-root", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "must be created on the 'dev' branch" in result.output
+
+    def test_refuse_dirty_tree(self, monkeypatch, tmp_path):
+        from click.testing import CliRunner
+        from galaxy_release_util.snapshot_release import cli
+
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.verify_galaxy_root", lambda x: None)
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.is_git_clean", lambda x: False)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["create-release-snapshot", "--galaxy-root", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "not clean" in result.output
+
+    def test_refuse_duplicate_local_tag(self, monkeypatch, tmp_path):
+        from click.testing import CliRunner
+        from galaxy_release_util.snapshot_release import cli
+
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.verify_galaxy_root", lambda x: None)
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.is_git_clean", lambda x: True)
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.get_current_branch", lambda x: "dev")
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release.load_repo_owner",
+            lambda *a, **kw: ("myuser", "mygalaxy"),
+        )
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release.get_root_version",
+            lambda x: Version("25.1.2"),
+        )
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release._tag_exists_locally",
+            lambda gx, tag: True,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["create-release-snapshot", "--galaxy-root", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "already exists locally" in result.output
+
+    def test_refuse_duplicate_remote_tag(self, monkeypatch, tmp_path):
+        from click.testing import CliRunner
+        from galaxy_release_util.snapshot_release import cli
+
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.verify_galaxy_root", lambda x: None)
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.is_git_clean", lambda x: True)
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.get_current_branch", lambda x: "dev")
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release.load_repo_owner",
+            lambda *a, **kw: ("myuser", "mygalaxy"),
+        )
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release.get_root_version",
+            lambda x: Version("25.1.2"),
+        )
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release._tag_exists_locally",
+            lambda gx, tag: False,
+        )
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release._tag_exists_on_remote",
+            lambda gx, remote, tag: True,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "create-release-snapshot", "--galaxy-root", str(tmp_path),
+            "--push-remote", "git@github.com:myuser/galaxy.git",
+        ])
+        assert result.exit_code != 0
+        assert "already exists on remote" in result.output

--- a/tests/test_snapshot_release.py
+++ b/tests/test_snapshot_release.py
@@ -7,55 +7,62 @@ from galaxy_release_util.snapshot_release import (
     CANONICAL_OWNER,
     CANONICAL_REPO,
     SNAPSHOT_TAG_PREFIX,
+    _url_points_to_canonical,
     find_canonical_upstream,
     find_last_snapshot_tag,
 )
 
 
 class TestFindCanonicalUpstream:
-    def _mock_remotes(self, output):
-        return patch(
-            "galaxy_release_util.snapshot_release.subprocess.run",
-            return_value=MagicMock(
-                stdout=output, returncode=0, check_returncode=lambda: None,
-            ),
-        )
+    """find_canonical_upstream enumerates remote names via `git remote` and then
+    calls `git remote get-url <name>` for each. These tests simulate that sequence.
+    """
+
+    def _mock_sequence(self, remote_map):
+        """Create a fake subprocess.run that handles `git remote` and `git remote get-url <name>`.
+
+        remote_map: dict of {remote_name: fetch_url}
+        """
+        def fake_run(cmd, **kwargs):
+            if cmd == ["git", "remote"]:
+                output = "\n".join(remote_map.keys()) + "\n" if remote_map else ""
+                return MagicMock(stdout=output, returncode=0, check_returncode=lambda: None)
+            if len(cmd) >= 4 and cmd[0] == "git" and cmd[1] == "remote" and cmd[2] == "get-url":
+                # Could be ["git", "remote", "get-url", name] or ["git", "remote", "get-url", "--push", name]
+                name = cmd[-1]
+                if name in remote_map:
+                    return MagicMock(stdout=remote_map[name] + "\n", returncode=0)
+                return MagicMock(stdout="", returncode=1, stderr="no such remote")
+            return MagicMock(stdout="", returncode=0, check_returncode=lambda: None)
+
+        return patch("galaxy_release_util.snapshot_release.subprocess.run", side_effect=fake_run)
 
     def test_ssh_remote(self):
-        remotes = "origin\tgit@github.com:guerler/galaxy.git (fetch)\nupstream\tgit@github.com:galaxyproject/galaxy.git (fetch)\n"
-        with self._mock_remotes(remotes):
+        with self._mock_sequence({
+            "origin": "git@github.com:guerler/galaxy.git",
+            "upstream": "git@github.com:galaxyproject/galaxy.git",
+        }):
             assert find_canonical_upstream(Path("/fake")) == "git@github.com:galaxyproject/galaxy.git"
 
     def test_https_remote(self):
-        remotes = "upstream\thttps://github.com/galaxyproject/galaxy.git (fetch)\n"
-        with self._mock_remotes(remotes):
+        with self._mock_sequence({"upstream": "https://github.com/galaxyproject/galaxy.git"}):
             assert find_canonical_upstream(Path("/fake")) == "https://github.com/galaxyproject/galaxy.git"
 
     def test_https_no_git_suffix(self):
-        remotes = "upstream\thttps://github.com/galaxyproject/galaxy (fetch)\n"
-        with self._mock_remotes(remotes):
+        with self._mock_sequence({"upstream": "https://github.com/galaxyproject/galaxy"}):
             assert find_canonical_upstream(Path("/fake")) == "https://github.com/galaxyproject/galaxy"
 
     def test_case_insensitive(self):
-        remotes = "upstream\thttps://github.com/GalaxyProject/Galaxy.git (fetch)\n"
-        with self._mock_remotes(remotes):
+        with self._mock_sequence({"upstream": "https://github.com/GalaxyProject/Galaxy.git"}):
             assert find_canonical_upstream(Path("/fake")) == "https://github.com/GalaxyProject/Galaxy.git"
 
     def test_no_match_returns_fallback(self):
-        remotes = "origin\tgit@github.com:guerler/galaxy.git (fetch)\n"
-        with self._mock_remotes(remotes):
-            url = find_canonical_upstream(Path("/fake"))
-            assert url == "https://github.com/galaxyproject/galaxy.git"
+        with self._mock_sequence({"origin": "git@github.com:guerler/galaxy.git"}):
+            assert find_canonical_upstream(Path("/fake")) == "https://github.com/galaxyproject/galaxy.git"
 
-    def test_ignores_push_lines(self):
-        remotes = (
-            "upstream\tgit@github.com:guerler/galaxy.git (fetch)\n"
-            "upstream\tgit@github.com:galaxyproject/galaxy.git (push)\n"
-        )
-        with self._mock_remotes(remotes):
-            # Should not match the push line, should fall back
-            url = find_canonical_upstream(Path("/fake"))
-            assert url == "https://github.com/galaxyproject/galaxy.git"
+    def test_no_remotes_returns_fallback(self):
+        with self._mock_sequence({}):
+            assert find_canonical_upstream(Path("/fake")) == "https://github.com/galaxyproject/galaxy.git"
 
 
 class TestFindLastSnapshotTag:
@@ -89,6 +96,35 @@ class TestFindLastSnapshotTag:
             assert f"{SNAPSHOT_TAG_PREFIX}25.1.*" in call_args
             assert "--merged" in call_args
             assert "HEAD" in call_args
+
+
+class TestUrlPointsToCanonical:
+    def test_ssh_canonical(self):
+        assert _url_points_to_canonical("git@github.com:galaxyproject/galaxy.git")
+
+    def test_ssh_canonical_no_suffix(self):
+        assert _url_points_to_canonical("git@github.com:galaxyproject/galaxy")
+
+    def test_https_canonical(self):
+        assert _url_points_to_canonical("https://github.com/galaxyproject/galaxy.git")
+
+    def test_https_canonical_no_suffix(self):
+        assert _url_points_to_canonical("https://github.com/galaxyproject/galaxy")
+
+    def test_https_canonical_trailing_slash(self):
+        assert _url_points_to_canonical("https://github.com/galaxyproject/galaxy/")
+
+    def test_case_insensitive(self):
+        assert _url_points_to_canonical("git@github.com:GalaxyProject/Galaxy.git")
+
+    def test_fork_not_canonical(self):
+        assert not _url_points_to_canonical("git@github.com:guerler/galaxy.git")
+
+    def test_different_repo_not_canonical(self):
+        assert not _url_points_to_canonical("git@github.com:galaxyproject/galaxy-hub.git")
+
+    def test_unrelated_url_not_canonical(self):
+        assert not _url_points_to_canonical("https://example.com/something/else.git")
 
 
 class TestVersionComputation:
@@ -190,6 +226,138 @@ class TestSafetyChecks:
         result = runner.invoke(cli, ["create-release-snapshot", "--galaxy-root", str(tmp_path)])
         assert result.exit_code != 0
         assert "already exists locally" in result.output
+
+    def test_refuse_push_remote_pointing_to_canonical(self, monkeypatch, tmp_path):
+        """Explicit --push-remote pointing at canonical galaxyproject/galaxy must be refused."""
+        from click.testing import CliRunner
+        from galaxy_release_util.snapshot_release import cli
+
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.verify_galaxy_root", lambda x: None)
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.is_git_clean", lambda x: True)
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.get_current_branch", lambda x: "dev")
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release.get_root_version",
+            lambda x: Version("25.1.2"),
+        )
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release.load_repo_owner",
+            lambda *a, **kw: ("myuser", "mygalaxy"),
+        )
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release._tag_exists_locally",
+            lambda gx, tag: False,
+        )
+        # Simulate the override path: user explicitly points --push-remote at canonical
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "create-release-snapshot",
+            "--galaxy-root", str(tmp_path),
+            "--push-remote", "git@github.com:galaxyproject/galaxy.git",
+        ])
+        assert result.exit_code != 0
+        assert "resolves to the canonical" in result.output
+        assert "galaxyproject/galaxy" in result.output
+
+    def test_refuse_push_remote_name_resolving_to_canonical(self, monkeypatch, tmp_path):
+        """--push-remote using a remote name that resolves to canonical must be refused."""
+        from click.testing import CliRunner
+        from galaxy_release_util.snapshot_release import cli
+
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.verify_galaxy_root", lambda x: None)
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.is_git_clean", lambda x: True)
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.get_current_branch", lambda x: "dev")
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release.get_root_version",
+            lambda x: Version("25.1.2"),
+        )
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release.load_repo_owner",
+            lambda *a, **kw: ("myuser", "mygalaxy"),
+        )
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release._tag_exists_locally",
+            lambda gx, tag: False,
+        )
+        # Simulate `git remote get-url upstream` resolving to canonical
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release._resolve_push_remote_url",
+            lambda gx, name: "git@github.com:galaxyproject/galaxy.git",
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "create-release-snapshot",
+            "--galaxy-root", str(tmp_path),
+            "--push-remote", "upstream",
+        ])
+        assert result.exit_code != 0
+        assert "resolves to the canonical" in result.output
+
+    def test_refuse_push_remote_with_divergent_pushurl(self, monkeypatch, tmp_path):
+        """A remote whose fetch URL is safe but pushurl points to canonical must be refused.
+
+        This is the dangerous divergence case: `git remote get-url <remote>` (without --push)
+        would return the safe fetch URL, but `git push <remote>` would dispatch to the
+        canonical push URL. The safety check must use the push URL.
+        """
+        from click.testing import CliRunner
+        from galaxy_release_util.snapshot_release import cli
+
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.verify_galaxy_root", lambda x: None)
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.is_git_clean", lambda x: True)
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.get_current_branch", lambda x: "dev")
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release.get_root_version",
+            lambda x: Version("25.1.2"),
+        )
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release.load_repo_owner",
+            lambda *a, **kw: ("myuser", "mygalaxy"),
+        )
+        monkeypatch.setattr(
+            "galaxy_release_util.snapshot_release._tag_exists_locally",
+            lambda gx, tag: False,
+        )
+
+        # Simulate subprocess: `git remote get-url --push origin` returns canonical URL.
+        # This is what a remote with `pushurl = git@github.com:galaxyproject/galaxy.git` would produce.
+        def fake_run(cmd, **kwargs):
+            if cmd[:4] == ["git", "remote", "get-url", "--push"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout="git@github.com:galaxyproject/galaxy.git\n",
+                    stderr="",
+                )
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.subprocess.run", fake_run)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "create-release-snapshot",
+            "--galaxy-root", str(tmp_path),
+            "--push-remote", "origin",
+        ])
+        assert result.exit_code != 0
+        assert "resolves to the canonical" in result.output
+
+    def test_resolver_uses_push_url_flag(self, monkeypatch, tmp_path):
+        """Verify the resolver calls `git remote get-url --push`, not the bare form.
+
+        This is a regression test for the fetch-vs-push URL safety bug.
+        """
+        from galaxy_release_util.snapshot_release import _resolve_push_remote_url
+
+        captured_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(cmd)
+            return MagicMock(returncode=0, stdout="git@github.com:guerler/galaxy.git\n")
+
+        monkeypatch.setattr("galaxy_release_util.snapshot_release.subprocess.run", fake_run)
+        _resolve_push_remote_url(tmp_path, "origin")
+
+        assert len(captured_cmds) == 1
+        assert captured_cmds[0] == ["git", "remote", "get-url", "--push", "origin"]
 
     def test_refuse_duplicate_remote_tag(self, monkeypatch, tmp_path):
         from click.testing import CliRunner


### PR DESCRIPTION
Explore a `create-release-snapshot` command to exercise the Galaxy release pipeline on a fork without touching the canonical repository. The command performs version bumping, changelog generation, package builds, tagging, and pushing a snapshot tag, while enforcing safety constraints such as clean working tree, dev branch alignment with upstream, and strict prevention of changing `galaxyproject/galaxy`. This enables repeatable validation of the release process and surfaces packaging or workflow issues before an actual release.