### PR TITLE
Fix config helper naming

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -125,7 +125,7 @@ All release metadata is defined in a single YAML config file. Once committed, al
 cd <GALAXY_ROOT>
 ```
 
-2. Create the release config file at `doc/source/releases/release_<RELEASE_TAG>.yml`:
+2. Create the release config file at `doc/source/releases/<RELEASE_TAG>_release.yml`:
 
 ```yaml
 current-version: "<RELEASE_TAG>"

--- a/TASKS.md
+++ b/TASKS.md
@@ -134,7 +134,7 @@ freeze-date: "<FREEZE_DATE>"
 release-date: "<RELEASE_DATE>"
 ```
 
-All fields are required. Two optional fields, `owner` and `repo`, default to `"galaxyproject"` and `"galaxy"` respectively. Override them only when working with a private or forked repository. The `next-version` value is provided via the `--next-version` CLI flag on commands that require it (e.g. `create-release-issue`, `create-changelog`).
+All fields are required. The `freeze-date` and `release-date` values must use `YYYY-MM-DD` format. Two optional fields, `owner` and `repo`, default to `"galaxyproject"` and `"galaxy"` respectively. Override them only when working with a private or forked repository. The `next-version` value is provided via the `--next-version` CLI flag on commands that require it (e.g. `create-release-issue`, `create-changelog`).
 
 3. Commit this file to the repository so it is available for all subsequent release commands.
 

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -260,15 +260,19 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
       > **Testing window:**
       > <START_DATE> through <END_DATE>
       >
+      > **Kick off Meeting:**
+      > <KICK_OFF_DATE_TIME>
+      > Video call link: <MEETING_LINK>
+      >
       > **Time commitment:**
-      > Approximately 1-2 hours per day. Testing consists of working through as many assigned PRs as time permits. There will be one short kick off meeting immediately before testing begins.
+      > Approximately 1-2 hours per day. Testing consists of working through as many assigned PRs as time permits. There will be one short kick off meeting at the start of the testing window.
       >
       > **What release testing involves:**
       > Release testing focuses on validating Galaxy GitHub pull requests. Each PR represents either a new feature, an enhancement, or a bug fix. Testing means exercising the changes as a user would and verifying that they behave correctly and do not introduce regressions. A curated list of PRs will be provided, and detailed guidance on the testing workflow and PR selection will be covered in the kick off meeting.
       >
-      > I will be available throughout the testing period, and the galaxyproject/release-testing channel on Element will be used for coordination and questions.
+      > I will be available throughout the testing period, and the galaxyproject/release-testing Matrix room at https://matrix.to/#/%23galaxyproject_release-testing:gitter.im will be used for coordination and questions.
       >
-      > If you are able to participate, I will follow up with concrete details.
+      > If you are able to participate, I can follow up with more details.
       >
       > Thanks!
 

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -343,7 +343,7 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
 
           galaxy-release-util check-blocking-prs ${version} --galaxy-root .
     - [ ] Ensure all pull requests merged into the pre-release branch during the freeze have [milestones attached](https://github.com/galaxyproject/galaxy/pulls?q=is%3Apr+is%3Aclosed+base%3Arelease_${version}+is%3Amerged+no%3Amilestone)
-    - [ ] Ensure all pull requests merged into the pre-release branch during the freeze are the not [${next_version} milestones](https://github.com/galaxyproject/galaxy/pulls?q=is%3Apr+is%3Aclosed+base%3Arelease_${version}+is%3Amerged+milestone%3A${next_version})
+    - [ ] Ensure all pull requests merged into the pre-release branch during the freeze are not in the [${next_version} milestone](https://github.com/galaxyproject/galaxy/pulls?q=is%3Apr+is%3Aclosed+base%3Arelease_${version}+is%3Amerged+milestone%3A${next_version})
     - [ ] Ensure release notes include all pull requests added during the freeze by re-running the release note bootstrapping:
 
           galaxy-release-util create-changelog ${version} --galaxy-root . --next-version ${next_version}

--- a/galaxy_release_util/cli/options.py
+++ b/galaxy_release_util/cli/options.py
@@ -53,7 +53,7 @@ release_config_option = click.option(
     "--release-config",
     type=click.Path(exists=True, path_type=pathlib.Path),
     default=None,
-    help="Path to release config YAML. Default: {galaxy-root}/doc/source/releases/release_{version}.yml",
+    help="Path to release config YAML. Default: {galaxy-root}/doc/source/releases/{version}_release.yml",
 )
 
 previous_version_option = click.option(

--- a/galaxy_release_util/release_config.py
+++ b/galaxy_release_util/release_config.py
@@ -31,7 +31,7 @@ def load_release_config(
 
     Resolution order:
     1. If --release-config is given, load that file (must exist).
-    2. Otherwise, try the default path {galaxy_root}/doc/source/releases/release_{version}.yml.
+    2. Otherwise, try the default path {galaxy_root}/doc/source/releases/{version}_release.yml.
     3. CLI flags (--previous-version, --next-version, --release-date, --freeze-date) override YAML values.
     4. If no YAML is found, all required values must come from CLI flags.
     """
@@ -82,7 +82,7 @@ def _try_load_yaml_config(
             raise FileNotFoundError(f"Release config not found: {release_config_path}")
         return _load_yaml_file(release_config_path, release_version)
 
-    default_path = galaxy_root / "doc" / "source" / "releases" / f"release_{release_version}.yml"
+    default_path = galaxy_root / "doc" / "source" / "releases" / f"{release_version}_release.yml"
     if not default_path.exists():
         return None
     return _load_yaml_file(default_path, release_version)
@@ -164,7 +164,7 @@ def load_repo_owner(
             raise FileNotFoundError(f"Release config not found: {release_config_path}")
         path = release_config_path
     else:
-        path = galaxy_root / "doc" / "source" / "releases" / f"release_{major_minor}.yml"
+        path = galaxy_root / "doc" / "source" / "releases" / f"{major_minor}_release.yml"
         if not path.exists():
             return ("galaxyproject", "galaxy")
     with open(path) as f:


### PR DESCRIPTION
Reordering the name for the release yml from `release_<VERSION>.yml` to `<VERSION>_release.yml` for consistency, all other file names in the same folder list the version first e.g. `<VERSION>_announce.rst`.