### PR TITLE
Derive release metadata from GitHub milestones, drop the config YAML

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -16,6 +16,8 @@ This document provides a step by step guide for preparing a Galaxy release. It c
 
 Discuss and agree on a tentative freeze date (FREEZE_DATE) and anticipated release date (RELEASE_DATE) with the team during a dev meeting. These dates are provisional until confirmed at the Freeze Meeting.
 
+RELEASE_DATE is recorded as the due date of the release milestone in Step 6, which is where `galaxy-release-util` reads it from. Whenever the date moves, update the milestone; nothing else needs changing.
+
 ---
 
 ### Step 2: Announce Freeze Meeting
@@ -125,7 +127,11 @@ GitHub milestones are the source of truth for release metadata. `galaxy-release-
 
 So the only setup required is a [milestone](https://github.com/galaxyproject/galaxy/milestones) titled `<RELEASE_TAG>` with its due date set to RELEASE_DATE. Nothing has to be committed to the Galaxy repository, and no command needs the dates passed on the command line.
 
+Open and closed milestones are both read, so PREVIOUS_RELEASE_TAG resolves from an already-closed milestone and the release notes can still be regenerated after RELEASE_TAG's own milestone is closed.
+
 Any value can still be overridden with a flag, for example `--release-date 2026-02-17` or `--next-version 26.2`. FREEZE_DATE is not recorded anywhere on GitHub, so `create-release-issue` takes it as `--freeze-date`.
+
+If GitHub cannot be reached, commands print a warning rather than failing: NEXT_RELEASE_TAG falls back to the next minor version and PREVIOUS_RELEASE_TAG to the newest release under `doc/source/releases`. RELEASE_DATE has no fallback, so a command that needs it will tell you to pass `--release-date`.
 
 #### Working against a fork
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -127,18 +127,13 @@ So the only setup required is a [milestone](https://github.com/galaxyproject/gal
 
 Any value can still be overridden with a flag, for example `--release-date 2026-02-17` or `--next-version 26.2`. FREEZE_DATE is not recorded anywhere on GitHub, so `create-release-issue` takes it as `--freeze-date`.
 
-#### Optional: release config YAML
+#### Working against a fork
 
-Values may also be pinned in a YAML file at `doc/source/releases/<RELEASE_TAG>_release.yml`, which is read automatically when it exists:
+Commands read `galaxyproject/galaxy` by default. Pass `--owner` and `--repo` to point them at a fork or private repository; this also decides which milestones are read:
 
-```yaml
-current-version: "<RELEASE_TAG>"
-previous-version: "<PREVIOUS_RELEASE_TAG>"
-freeze-date: "<FREEZE_DATE>"
-release-date: "<RELEASE_DATE>"
+```bash
+galaxy-release-util create-changelog <RELEASE_TAG> --owner <OWNER> --repo <REPO>
 ```
-
-Every field is optional; anything omitted is resolved from the milestones. Dates use `YYYY-MM-DD` format. Two further fields, `owner` and `repo`, default to `"galaxyproject"` and `"galaxy"` — set them when working against a fork or private repository, since they also decide which milestones are read.
 
 ---
 
@@ -160,7 +155,7 @@ cd <GALAXY_ROOT>
 galaxy-release-util create-release-issue <RELEASE_TAG> --freeze-date <FREEZE_DATE> --dry-run
 ```
 
-Everything else is read from the milestones. To use a config file at a non-default location, add `--release-config /path/to/config.yml`.
+Everything else is read from the milestones.
 
 4. Re run the command without `--dry-run` to open the issue on GitHub.
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -115,17 +115,21 @@ export GITHUB_AUTH=<TOKEN>
 
 ---
 
-### Step 6: Create Release Config YAML
+### Step 6: Create the GitHub Milestone
 
-All release metadata is defined in a single YAML config file. Once committed, all `galaxy-release-util` commands load it automatically from the default path given a release version.
+GitHub milestones are the source of truth for release metadata. `galaxy-release-util` reads them to work out:
 
-1. Change to your Galaxy root directory:
+* RELEASE_DATE, from the due date of the milestone named after RELEASE_TAG
+* PREVIOUS_RELEASE_TAG, the newest milestone preceding RELEASE_TAG
+* NEXT_RELEASE_TAG, the oldest milestone following RELEASE_TAG
 
-```bash
-cd <GALAXY_ROOT>
-```
+So the only setup required is a [milestone](https://github.com/galaxyproject/galaxy/milestones) titled `<RELEASE_TAG>` with its due date set to RELEASE_DATE. Nothing has to be committed to the Galaxy repository, and no command needs the dates passed on the command line.
 
-2. Create the release config file at `doc/source/releases/<RELEASE_TAG>_release.yml`:
+Any value can still be overridden with a flag, for example `--release-date 2026-02-17` or `--next-version 26.2`. FREEZE_DATE is not recorded anywhere on GitHub, so `create-release-issue` takes it as `--freeze-date`.
+
+#### Optional: release config YAML
+
+Values may also be pinned in a YAML file at `doc/source/releases/<RELEASE_TAG>_release.yml`, which is read automatically when it exists:
 
 ```yaml
 current-version: "<RELEASE_TAG>"
@@ -134,9 +138,7 @@ freeze-date: "<FREEZE_DATE>"
 release-date: "<RELEASE_DATE>"
 ```
 
-All fields are required. The `freeze-date` and `release-date` values must use `YYYY-MM-DD` format. Two optional fields, `owner` and `repo`, default to `"galaxyproject"` and `"galaxy"` respectively. Override them only when working with a private or forked repository. The `next-version` value is provided via the `--next-version` CLI flag on commands that require it (e.g. `create-release-issue`, `create-changelog`).
-
-3. Commit this file to the repository so it is available for all subsequent release commands.
+Every field is optional; anything omitted is resolved from the milestones. Dates use `YYYY-MM-DD` format. Two further fields, `owner` and `repo`, default to `"galaxyproject"` and `"galaxy"` — set them when working against a fork or private repository, since they also decide which milestones are read.
 
 ---
 
@@ -155,10 +157,10 @@ cd <GALAXY_ROOT>
 3. Review the generated release issue content:
 
 ```bash
-galaxy-release-util create-release-issue <RELEASE_TAG> --galaxy-root . --next-version <NEXT_RELEASE_TAG> --dry-run
+galaxy-release-util create-release-issue <RELEASE_TAG> --freeze-date <FREEZE_DATE> --dry-run
 ```
 
-To use a config file at a non-default location, add `--release-config /path/to/config.yml`.
+Everything else is read from the milestones. To use a config file at a non-default location, add `--release-config /path/to/config.yml`.
 
 4. Re run the command without `--dry-run` to open the issue on GitHub.
 

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -38,7 +38,11 @@ from .metadata import (
     get_repo_name,
     strip_release,
 )
-from .release_config import load_release_config
+from .release_config import (
+    ReleaseConfig,
+    load_release_config,
+    load_repo_owner,
+)
 from .util import (
     escape_rst_inline,
     verify_galaxy_root,
@@ -320,7 +324,7 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
           git checkout release_${version} -b ${version}_release_notes
     - [ ] Bootstrap the release notes
 
-          galaxy-release-util create-changelog ${version} --galaxy-root . --next-version ${next_version}
+          galaxy-release-util create-changelog ${version}
     - [ ] Open newly created files and manually curate major topics and release notes.
     - [ ] Run ``python scripts/release-diff.py release_${previous_version}`` and add configuration changes to release notes.
     - [ ] Add new release to doc/source/releases/index.rst
@@ -342,15 +346,15 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
 
     - [ ] Ensure all [blocking milestone issues](https://github.com/galaxyproject/galaxy/issues?q=is%3Aopen+is%3Aissue+milestone%3A${version}) have been resolved.
 
-          galaxy-release-util check-blocking-issues ${version} --galaxy-root .
+          galaxy-release-util check-blocking-issues ${version}
     - [ ] Ensure all [blocking milestone pull requests](https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+milestone%3A${version}) have been merged, closed, or postponed until the next release.
 
-          galaxy-release-util check-blocking-prs ${version} --galaxy-root .
+          galaxy-release-util check-blocking-prs ${version}
     - [ ] Ensure all pull requests merged into the pre-release branch during the freeze have [milestones attached](https://github.com/galaxyproject/galaxy/pulls?q=is%3Apr+is%3Aclosed+base%3Arelease_${version}+is%3Amerged+no%3Amilestone)
     - [ ] Ensure all pull requests merged into the pre-release branch during the freeze are not in the [${next_version} milestone](https://github.com/galaxyproject/galaxy/pulls?q=is%3Apr+is%3Aclosed+base%3Arelease_${version}+is%3Amerged+milestone%3A${next_version})
     - [ ] Ensure release notes include all pull requests added during the freeze by re-running the release note bootstrapping:
 
-          galaxy-release-util create-changelog ${version} --galaxy-root . --next-version ${next_version}
+          galaxy-release-util create-changelog ${version}
     - [ ] Ensure previous release is merged into current. [GitHub branch comparison](https://github.com/galaxyproject/galaxy/compare/release_${version}...release_${previous_version})
     - [ ] Create the first point release (v${version}.0) using the instructions at https://docs.galaxyproject.org/en/master/dev/create_release.html#creating-galaxy-point-releases
 
@@ -381,8 +385,22 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
 release_version_argument = click.argument("release-version", type=ClickVersion())
 
 dry_run_option = click.option(
-    "--dry-run", is_flag=True, default=False, help="Do not connect to GitHub's API, print out output"
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print what would happen instead of opening issues or collecting pull requests.",
 )
+
+
+def _resolve_config(*required: str, **kwargs) -> ReleaseConfig:
+    """Resolve the release config and assert that the values this command needs are known."""
+    try:
+        config = load_release_config(**kwargs)
+        config.require(*required)
+    except (ValueError, FileNotFoundError) as e:
+        raise click.UsageError(str(e)) from e
+    return config
+
 
 @click.group(help="Subcommands of this script can perform various tasks around creating Galaxy releases")
 def cli():
@@ -411,14 +429,24 @@ def create_release_issue(
     dry_run: bool,
 ):
     verify_galaxy_root(galaxy_root)
-    config = load_release_config(
-        galaxy_root, release_version, release_config,
-        previous_version, next_version, release_date, freeze_date,
+    config = _resolve_config(
+        "previous_version",
+        "next_version",
+        "release_date",
+        "freeze_date",
+        galaxy_root=galaxy_root,
+        release_version=release_version,
+        release_config_path=release_config,
+        previous_version=previous_version,
+        next_version=next_version,
+        release_date=release_date,
+        freeze_date=freeze_date,
     )
-    if config.next_version is None:
-        raise click.UsageError("--next-version is required for create-release-issue")
+    assert config.next_version
     if config.next_version <= config.current_version:
-        raise click.UsageError(f"--next-version ({config.next_version}) must be greater than release version ({config.current_version})")
+        raise click.UsageError(
+            f"--next-version ({config.next_version}) must be greater than release version ({config.current_version})"
+        )
 
     issue_template_params = dict(
         version=release_version,
@@ -454,29 +482,29 @@ def create_release_issue(
     release_version_argument,
     galaxy_root_option,
     release_config_option,
-    previous_version_option,
     next_version_option,
     release_date_option,
-    freeze_date_option,
     dry_run_option,
 )
 def create_changelog(
     release_version: Version,
     galaxy_root: Path,
     release_config: Optional[Path],
-    previous_version: Optional[Version],
     next_version: Optional[Version],
     release_date: Optional[datetime.date],
-    freeze_date: Optional[datetime.date],
     dry_run: bool,
 ):
     verify_galaxy_root(galaxy_root)
-    config = load_release_config(
-        galaxy_root, release_version, release_config,
-        previous_version, next_version, release_date, freeze_date,
+    config = _resolve_config(
+        "release_date",
+        "next_version",
+        galaxy_root=galaxy_root,
+        release_version=release_version,
+        release_config_path=release_config,
+        next_version=next_version,
+        release_date=release_date,
     )
-    if config.next_version is None:
-        raise click.UsageError("--next-version is required for create-changelog")
+    assert config.release_date and config.next_version
     release_date = config.release_date
     next_version = config.next_version
 
@@ -517,27 +545,30 @@ def create_changelog(
     release_version_argument,
     galaxy_root_option,
     release_config_option,
-    previous_version_option,
     release_date_option,
-    freeze_date_option,
     dry_run_option,
 )
 def check_blocking_prs(
     release_version: Version,
     galaxy_root: Path,
     release_config: Optional[Path],
-    previous_version: Optional[Version],
     release_date: Optional[datetime.date],
-    freeze_date: Optional[datetime.date],
     dry_run: bool,
 ):
     verify_galaxy_root(galaxy_root)
-    config = load_release_config(
-        galaxy_root, release_version, release_config,
-        previous_version, None, release_date, freeze_date,
+    config = _resolve_config(
+        "release_date",
+        galaxy_root=galaxy_root,
+        release_version=release_version,
+        release_config_path=release_config,
+        release_date=release_date,
     )
+    assert config.release_date
     if dry_run:
-        click.echo(f"Dry run: would check blocking PRs for milestone {release_version}")
+        click.echo(
+            f"Dry run: would check blocking PRs for milestone {release_version} "
+            f"(release date {config.release_date})"
+        )
         sys.exit(0)
     block = 0
     for pr in _get_prs(release_version, config.release_date, config.owner, config.repo, state="open"):
@@ -551,31 +582,23 @@ def check_blocking_prs(
     release_version_argument,
     galaxy_root_option,
     release_config_option,
-    previous_version_option,
-    release_date_option,
-    freeze_date_option,
     dry_run_option,
 )
 def check_blocking_issues(
     release_version: Version,
     galaxy_root: Path,
     release_config: Optional[Path],
-    previous_version: Optional[Version],
-    release_date: Optional[datetime.date],
-    freeze_date: Optional[datetime.date],
     dry_run: bool,
 ):
     verify_galaxy_root(galaxy_root)
-    config = load_release_config(
-        galaxy_root, release_version, release_config,
-        previous_version, None, release_date, freeze_date,
-    )
+    # Issues are selected by milestone alone, so the repository name is all we need.
+    owner, repo_name = load_repo_owner(galaxy_root, release_version, release_config)
     if dry_run:
         click.echo(f"Dry run: would check blocking issues for milestone {release_version}")
         sys.exit(0)
     block = 0
     github = github_client()
-    repo = github.get_repo(get_repo_name(config.owner, config.repo))
+    repo = github.get_repo(get_repo_name(owner, repo_name))
     issues = repo.get_issues(state="open")
     for issue in issues:
         if (

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -198,7 +198,7 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
 - [ ] **Freeze Release (on or around ${freeze_date})**
 
     - [ ] Verify that your installed version of `galaxy-release-util` is up-to-date.
-    - [ ] [Create milestone](https://github.com/galaxyproject/galaxy/milestones) `${next_version}` for next release. Note the milestone number from the URL (`https://github.com/galaxyproject/galaxy/milestone/<NUMBER>`).
+    - [ ] [Create milestone](https://github.com/galaxyproject/galaxy/milestones) `${next_version}` for next release and **set its due date** to the planned release date. `galaxy-release-util` reads that due date as the release date for `${next_version}`, so leaving it empty will block the next release's changelog. Note the milestone number from the URL (`https://github.com/galaxyproject/galaxy/milestone/<NUMBER>`).
     - [ ] Update ``MILESTONE_NUMBER`` in the [maintenance bot](https://github.com/galaxyproject/galaxy/blob/dev/.github/workflows/maintenance_bot.yaml) to reference `${next_version}` so it properly tags new pull requests. Open a pull request to apply the change.
     - [ ] Hold the Freeze Meeting (one week before freeze, usually during a weekly dev meeting). Review [open milestone pull requests](https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+milestone%3A${version}+-label%3Akind%2Fbug+-is%3Adraft), decide what will be included in `${version}`, and assign reviewers to ensure merges complete before the freeze.
     - [ ] Audit milestone labels. Ensure all open pull requests in the milestone have appropriate `kind/*` labels and correct milestone assignment. [Find unlabeled PRs](https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+milestone%3A${version}+-label%3A%22kind%2Ffeature%22+-label%3A%22kind%2Fbug%22+-label%3A%22kind%2Fenhancement%22+-label%3A%22kind%2Frefactoring%22+-label%3Adependencies).
@@ -325,7 +325,11 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
     - [ ] Bootstrap the release notes
 
           galaxy-release-util create-changelog ${version}
-    - [ ] Open newly created files and manually curate major topics and release notes.
+
+      Run this from the Galaxy root. The release date and `${next_version}` are read from the milestones; pass `--release-date` or `--next-version` to override either.
+
+      Note: each run rewrites ``${version}_announce.rst`` from the template. ``${version}_announce_user.rst``, ``${version}_prs.rst`` and the ``${next_version}`` stub are preserved and only gain newly merged pull requests, so re-running to pick up new pull requests costs you only the admin-facing file.
+    - [ ] Open newly created files and manually curate major topics and release notes. Leave the admin notes in ``${version}_announce.rst`` until after the final re-run below, or keep them elsewhere until then.
     - [ ] Run ``python scripts/release-diff.py release_${previous_version}`` and add configuration changes to release notes.
     - [ ] Add new release to doc/source/releases/index.rst
     - [ ] Open a pull request for the release notes branch.
@@ -355,6 +359,8 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
     - [ ] Ensure release notes include all pull requests added during the freeze by re-running the release note bootstrapping:
 
           galaxy-release-util create-changelog ${version}
+
+      This rewrites ``${version}_announce.rst`` from the template again, so re-apply the admin notes afterwards.
     - [ ] Ensure previous release is merged into current. [GitHub branch comparison](https://github.com/galaxyproject/galaxy/compare/release_${version}...release_${previous_version})
     - [ ] Create the first point release (v${version}.0) using the instructions at https://docs.galaxyproject.org/en/master/dev/create_release.html#creating-galaxy-point-releases
 
@@ -377,7 +383,7 @@ RELEASE_ISSUE_TEMPLATE = string.Template(
 
 - [ ] **Complete release**
 
-    - [ ] Close milestone ``${version}`` and ensure milestone ``${next_version}`` exists.
+    - [ ] Close milestone ``${version}`` and ensure milestone ``${next_version}`` exists with its due date set. Closing ``${version}`` is safe: milestones are read regardless of state, so the ``${version}`` release notes can still be regenerated afterwards.
     - [ ] Close this issue.
 """  # noqa: E501
 )

--- a/galaxy_release_util/bootstrap_history.py
+++ b/galaxy_release_util/bootstrap_history.py
@@ -24,9 +24,10 @@ from .cli.options import (
     galaxy_root_option,
     group_options,
     next_version_option,
+    owner_option,
     previous_version_option,
-    release_config_option,
     release_date_option,
+    repo_option,
 )
 from .github_client import github_client
 from .metadata import (
@@ -41,7 +42,6 @@ from .metadata import (
 from .release_config import (
     ReleaseConfig,
     load_release_config,
-    load_repo_owner,
 )
 from .util import (
     escape_rst_inline,
@@ -411,7 +411,8 @@ def cli():
 @group_options(
     release_version_argument,
     galaxy_root_option,
-    release_config_option,
+    owner_option,
+    repo_option,
     previous_version_option,
     next_version_option,
     release_date_option,
@@ -421,7 +422,8 @@ def cli():
 def create_release_issue(
     release_version: Version,
     galaxy_root: Path,
-    release_config: Optional[Path],
+    owner: str,
+    repo: str,
     previous_version: Optional[Version],
     next_version: Optional[Version],
     release_date: Optional[datetime.date],
@@ -436,7 +438,8 @@ def create_release_issue(
         "freeze_date",
         galaxy_root=galaxy_root,
         release_version=release_version,
-        release_config_path=release_config,
+        owner=owner,
+        repo=repo,
         previous_version=previous_version,
         next_version=next_version,
         release_date=release_date,
@@ -464,8 +467,8 @@ def create_release_issue(
         return None
     try:
         github = github_client()
-        repo = github.get_repo(get_repo_name(config.owner, config.repo))
-        release_issue = repo.create_issue(
+        github_repo = github.get_repo(get_repo_name(config.owner, config.repo))
+        release_issue = github_repo.create_issue(
             title=issue_title,
             body=issue_contents,
         )
@@ -481,7 +484,8 @@ def create_release_issue(
 @group_options(
     release_version_argument,
     galaxy_root_option,
-    release_config_option,
+    owner_option,
+    repo_option,
     next_version_option,
     release_date_option,
     dry_run_option,
@@ -489,7 +493,8 @@ def create_release_issue(
 def create_changelog(
     release_version: Version,
     galaxy_root: Path,
-    release_config: Optional[Path],
+    owner: str,
+    repo: str,
     next_version: Optional[Version],
     release_date: Optional[datetime.date],
     dry_run: bool,
@@ -500,7 +505,8 @@ def create_changelog(
         "next_version",
         galaxy_root=galaxy_root,
         release_version=release_version,
-        release_config_path=release_config,
+        owner=owner,
+        repo=repo,
         next_version=next_version,
         release_date=release_date,
     )
@@ -544,14 +550,16 @@ def create_changelog(
 @group_options(
     release_version_argument,
     galaxy_root_option,
-    release_config_option,
+    owner_option,
+    repo_option,
     release_date_option,
     dry_run_option,
 )
 def check_blocking_prs(
     release_version: Version,
     galaxy_root: Path,
-    release_config: Optional[Path],
+    owner: str,
+    repo: str,
     release_date: Optional[datetime.date],
     dry_run: bool,
 ):
@@ -560,7 +568,8 @@ def check_blocking_prs(
         "release_date",
         galaxy_root=galaxy_root,
         release_version=release_version,
-        release_config_path=release_config,
+        owner=owner,
+        repo=repo,
         release_date=release_date,
     )
     assert config.release_date
@@ -581,25 +590,26 @@ def check_blocking_prs(
 @group_options(
     release_version_argument,
     galaxy_root_option,
-    release_config_option,
+    owner_option,
+    repo_option,
     dry_run_option,
 )
 def check_blocking_issues(
     release_version: Version,
     galaxy_root: Path,
-    release_config: Optional[Path],
+    owner: str,
+    repo: str,
     dry_run: bool,
 ):
     verify_galaxy_root(galaxy_root)
-    # Issues are selected by milestone alone, so the repository name is all we need.
-    owner, repo_name = load_repo_owner(galaxy_root, release_version, release_config)
+    # Issues are selected by milestone alone, so no dates need resolving here.
     if dry_run:
         click.echo(f"Dry run: would check blocking issues for milestone {release_version}")
         sys.exit(0)
     block = 0
     github = github_client()
-    repo = github.get_repo(get_repo_name(owner, repo_name))
-    issues = repo.get_issues(state="open")
+    github_repo = github.get_repo(get_repo_name(owner, repo))
+    issues = github_repo.get_issues(state="open")
     for issue in issues:
         if (
             issue.milestone

--- a/galaxy_release_util/cli/options.py
+++ b/galaxy_release_util/cli/options.py
@@ -49,11 +49,18 @@ class ClickDate(click.ParamType):
             self.fail(f"{value!r} is not a valid date: {str(e)}", param, ctx)
 
 
-release_config_option = click.option(
-    "--release-config",
-    type=click.Path(exists=True, path_type=pathlib.Path),
-    default=None,
-    help="Path to release config YAML. Default: {galaxy-root}/doc/source/releases/{version}_release.yml",
+owner_option = click.option(
+    "--owner",
+    default="galaxyproject",
+    show_default=True,
+    help="GitHub organization or user owning the repository. Set when working against a fork.",
+)
+
+repo_option = click.option(
+    "--repo",
+    default="galaxy",
+    show_default=True,
+    help="GitHub repository name. Set when working against a fork.",
 )
 
 previous_version_option = click.option(

--- a/galaxy_release_util/cli/options.py
+++ b/galaxy_release_util/cli/options.py
@@ -60,26 +60,26 @@ previous_version_option = click.option(
     "--previous-version",
     type=ClickVersion(),
     default=None,
-    help="Previous release version (overrides config YAML).",
+    help="Previous release version. Defaults to the newest milestone preceding the release version.",
 )
 
 next_version_option = click.option(
     "--next-version",
     type=ClickVersion(),
     default=None,
-    help="Next planned release version (required for create-release-issue and create-changelog). The first release of a year is YY.0; subsequent releases increment the minor version.",
+    help="Next planned release version. Defaults to the oldest milestone following the release version.",
 )
 
 release_date_option = click.option(
     "--release-date",
     type=ClickDate(),
     default=None,
-    help="Release date in YYYY-MM-DD format (overrides config YAML).",
+    help="Release date in YYYY-MM-DD format. Defaults to the due date of the release version's milestone.",
 )
 
 freeze_date_option = click.option(
     "--freeze-date",
     type=ClickDate(),
     default=None,
-    help="Freeze date in YYYY-MM-DD format (overrides config YAML).",
+    help="Freeze date in YYYY-MM-DD format. Not derivable from milestones, so it must be supplied.",
 )

--- a/galaxy_release_util/point_release.py
+++ b/galaxy_release_util/point_release.py
@@ -29,7 +29,8 @@ from .cli.options import (
     ClickVersion,
     galaxy_root_option,
     group_options,
-    release_config_option,
+    owner_option,
+    repo_option,
 )
 from .github_client import github_client
 from .metadata import (
@@ -39,7 +40,6 @@ from .metadata import (
     get_repo_name,
     strip_release,
 )
-from .release_config import load_repo_owner
 from .util import (
     escape_rst_inline,
     verify_galaxy_root,
@@ -690,7 +690,7 @@ def build_and_upload(
 @click.option("--build-packages/--no-build-packages", type=bool, is_flag=True, default=True)
 @click.option("--upload-packages", type=bool, is_flag=True, default=False)
 @click.option("--upstream", type=str, default=None, help="Git upstream URL. Default: git@github.com:{owner}/{repo}.git")
-@group_options(release_config_option, packages_option, no_confirm_option)
+@group_options(owner_option, repo_option, packages_option, no_confirm_option)
 def create_point_release(
     galaxy_root: Path,
     new_version: Version,
@@ -700,10 +700,10 @@ def create_point_release(
     upload_packages: bool,
     no_confirm: bool,
     upstream: Optional[str],
-    release_config: Optional[Path],
+    owner: str,
+    repo: str,
 ):
     verify_galaxy_root(galaxy_root)
-    owner, repo = load_repo_owner(galaxy_root, new_version, release_config)
     if upstream is None:
         upstream = f"git@github.com:{get_repo_name(owner, repo)}.git"
     check_galaxy_repo_is_clean(galaxy_root)

--- a/galaxy_release_util/release_config.py
+++ b/galaxy_release_util/release_config.py
@@ -6,11 +6,9 @@ from pathlib import Path
 from typing import (
     Dict,
     Optional,
-    Tuple,
 )
 
 import click
-import yaml
 from packaging.version import (
     InvalidVersion,
     Version,
@@ -28,7 +26,7 @@ RELEASE_NOTES_FILENAME = re.compile(r"^(\d+\.\d+)\.rst$")
 
 @dataclass
 class ReleaseConfig:
-    """Release metadata, resolved from CLI flags, an optional YAML config and GitHub milestones.
+    """Release metadata, resolved from CLI flags and GitHub milestones.
 
     Every value except ``current_version`` is optional: commands declare what they
     actually need via :meth:`require`, so a command never fails over a value it
@@ -50,50 +48,40 @@ class ReleaseConfig:
             raise ValueError(
                 f"Could not determine {', '.join(missing)} for release {self.current_version}. "
                 f"Expected a milestone titled '{self.current_version}' with a due date in "
-                f"{get_repo_name(self.owner, self.repo)}. Pass the value(s) explicitly, or add them to a "
-                f"release config YAML."
+                f"{get_repo_name(self.owner, self.repo)}. Pass the value(s) explicitly."
             )
 
 
 def load_release_config(
     galaxy_root: Path,
     release_version: Version,
-    release_config_path: Optional[Path] = None,
     previous_version: Optional[Version] = None,
     next_version: Optional[Version] = None,
     release_date: Optional[datetime.date] = None,
     freeze_date: Optional[datetime.date] = None,
+    owner: str = PROJECT_OWNER,
+    repo: str = PROJECT_NAME,
     use_github: bool = True,
 ) -> ReleaseConfig:
     """Resolve release metadata for ``release_version``.
 
-    Resolution order, highest precedence first:
+    Values given as CLI flags win. Anything left over is read from the GitHub
+    milestones of ``owner``/``repo``, which are the source of truth for release
+    dates and for the surrounding release versions. If GitHub cannot be reached,
+    what can be derived locally is derived locally.
 
-    1. CLI flags (``--previous-version``, ``--next-version``, ``--release-date``, ``--freeze-date``).
-    2. A release config YAML: the file given by ``--release-config``, or
-       ``{galaxy_root}/doc/source/releases/{version}_release.yml`` if it exists.
-       The YAML is optional and so are all of its fields.
-    3. GitHub milestones, the source of truth for release dates and for the
-       surrounding release versions.
-    4. Locally derived fallbacks, used when GitHub is unreachable.
-
-    Values that cannot be resolved are left as ``None``; use :meth:`ReleaseConfig.require`
+    Values that stay unresolved are left as ``None``; use :meth:`ReleaseConfig.require`
     to assert on the ones a given command needs.
     """
-    config = _try_load_yaml_config(galaxy_root, release_version, release_config_path)
-    if config is None:
-        config = ReleaseConfig(current_version=release_version)
-
-    # CLI flags override anything from the YAML.
-    if previous_version is not None:
-        config.previous_version = previous_version
-    if next_version is not None:
-        config.next_version = next_version
-    if release_date is not None:
-        config.release_date = release_date
-    if freeze_date is not None:
-        config.freeze_date = freeze_date
-
+    config = ReleaseConfig(
+        current_version=release_version,
+        previous_version=previous_version,
+        next_version=next_version,
+        release_date=release_date,
+        freeze_date=freeze_date,
+        owner=owner,
+        repo=repo,
+    )
     if use_github:
         _fill_from_milestones(config)
     _fill_from_local_fallbacks(config, galaxy_root)
@@ -161,113 +149,3 @@ def _previous_release_from_docs(galaxy_root: Path, version: Version) -> Optional
             documented.append(Version(match.group(1)))
     earlier = [documented_version for documented_version in documented if documented_version < version]
     return max(earlier) if earlier else None
-
-
-def _try_load_yaml_config(
-    galaxy_root: Path,
-    release_version: Version,
-    release_config_path: Optional[Path],
-) -> Optional[ReleaseConfig]:
-    """Try to load a YAML config file, returning None if no file is found at the default path."""
-    if release_config_path is not None:
-        if not release_config_path.exists():
-            raise FileNotFoundError(f"Release config not found: {release_config_path}")
-        return _load_yaml_file(release_config_path, release_version)
-
-    default_path = _default_config_path(galaxy_root, release_version)
-    if not default_path.exists():
-        return None
-    return _load_yaml_file(default_path, release_version)
-
-
-def _default_config_path(galaxy_root: Path, release_version: Version) -> Path:
-    return galaxy_root / "doc" / "source" / "releases" / f"{release_version}_release.yml"
-
-
-def _load_yaml_file(path: Path, release_version: Version) -> ReleaseConfig:
-    """Load and validate a YAML release config file.
-
-    All fields are optional, but a field that is present must hold a valid value.
-    """
-    data = _read_yaml_mapping(path)
-    current_version = _optional_version(data, "current-version", path)
-    if current_version is not None and current_version != release_version:
-        raise ValueError(
-            f"'current-version' in config ({current_version}) does not match "
-            f"release-version argument ({release_version})"
-        )
-    return ReleaseConfig(
-        current_version=release_version,
-        previous_version=_optional_version(data, "previous-version", path),
-        next_version=_optional_version(data, "next-version", path),
-        release_date=_optional_date(data, "release-date", path),
-        freeze_date=_optional_date(data, "freeze-date", path),
-        owner=data.get("owner") or PROJECT_OWNER,
-        repo=data.get("repo") or PROJECT_NAME,
-    )
-
-
-def load_repo_owner(
-    galaxy_root: Path,
-    release_version: Version,
-    release_config_path: Optional[Path] = None,
-) -> Tuple[str, str]:
-    """Load owner and repo from release config YAML.
-
-    For point releases (e.g. 26.0.1), derives the major.minor version (26.0)
-    to locate the config file. Returns (owner, repo) tuple, falling back to
-    defaults only if no config file exists at the default path.
-    """
-    major_minor = Version(f"{release_version.major}.{release_version.minor}")
-    if release_config_path is not None:
-        if not release_config_path.exists():
-            raise FileNotFoundError(f"Release config not found: {release_config_path}")
-        path = release_config_path
-    else:
-        path = _default_config_path(galaxy_root, major_minor)
-        if not path.exists():
-            return (PROJECT_OWNER, PROJECT_NAME)
-    data = _read_yaml_mapping(path)
-    return (data.get("owner") or PROJECT_OWNER, data.get("repo") or PROJECT_NAME)
-
-
-def _read_yaml_mapping(path: Path) -> dict:
-    with open(path) as f:
-        data = yaml.safe_load(f)
-    if data is None:
-        return {}
-    if not isinstance(data, dict):
-        raise ValueError(f"Release config must be a YAML mapping, got {type(data).__name__} in {path}")
-    return data
-
-
-def _optional_version(data: dict, field: str, path: Path) -> Optional[Version]:
-    if field not in data:
-        return None
-    value = data[field]
-    if value is None:
-        raise ValueError(f"Field '{field}' is present but has no value in {path}")
-    try:
-        return Version(str(value))
-    except InvalidVersion as e:
-        raise ValueError(f"Invalid '{field}' value {value!r} in {path}: {e}")
-
-
-def _optional_date(data: dict, field: str, path: Path) -> Optional[datetime.date]:
-    if field not in data:
-        return None
-    value = data[field]
-    if value is None:
-        raise ValueError(f"Field '{field}' is present but has no value in {path}")
-    try:
-        return _parse_date(value)
-    except ValueError as e:
-        raise ValueError(f"Invalid '{field}' value {value!r} in {path}: {e}")
-
-
-def _parse_date(value) -> datetime.date:
-    if isinstance(value, datetime.datetime):
-        return value.date()
-    if isinstance(value, datetime.date):
-        return value
-    return datetime.datetime.strptime(str(value), "%Y-%m-%d").date()

--- a/galaxy_release_util/release_config.py
+++ b/galaxy_release_util/release_config.py
@@ -1,21 +1,58 @@
 import datetime
+import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import (
+    Dict,
+    Optional,
+    Tuple,
+)
 
+import click
 import yaml
-from packaging.version import Version
+from packaging.version import (
+    InvalidVersion,
+    Version,
+)
+
+from .github_client import github_client
+from .metadata import (
+    PROJECT_NAME,
+    PROJECT_OWNER,
+    get_repo_name,
+)
+
+RELEASE_NOTES_FILENAME = re.compile(r"^(\d+\.\d+)\.rst$")
 
 
 @dataclass
 class ReleaseConfig:
+    """Release metadata, resolved from CLI flags, an optional YAML config and GitHub milestones.
+
+    Every value except ``current_version`` is optional: commands declare what they
+    actually need via :meth:`require`, so a command never fails over a value it
+    does not use.
+    """
+
     current_version: Version
-    previous_version: Version
-    release_date: datetime.date
-    freeze_date: datetime.date
+    previous_version: Optional[Version] = None
+    release_date: Optional[datetime.date] = None
+    freeze_date: Optional[datetime.date] = None
     next_version: Optional[Version] = None
-    owner: str = "galaxyproject"
-    repo: str = "galaxy"
+    owner: str = PROJECT_OWNER
+    repo: str = PROJECT_NAME
+
+    def require(self, *fields: str) -> None:
+        """Raise if any of ``fields`` could not be resolved."""
+        missing = [f"--{field.replace('_', '-')}" for field in fields if getattr(self, field) is None]
+        if missing:
+            raise ValueError(
+                f"Could not determine {', '.join(missing)} for release {self.current_version}. "
+                f"Expected a milestone titled '{self.current_version}' with a due date in "
+                f"{get_repo_name(self.owner, self.repo)}. Pass the value(s) explicitly, or add them to a "
+                f"release config YAML."
+            )
 
 
 def load_release_config(
@@ -26,49 +63,104 @@ def load_release_config(
     next_version: Optional[Version] = None,
     release_date: Optional[datetime.date] = None,
     freeze_date: Optional[datetime.date] = None,
+    use_github: bool = True,
 ) -> ReleaseConfig:
-    """Load release config from YAML, CLI flags, or both.
+    """Resolve release metadata for ``release_version``.
 
-    Resolution order:
-    1. If --release-config is given, load that file (must exist).
-    2. Otherwise, try the default path {galaxy_root}/doc/source/releases/{version}_release.yml.
-    3. CLI flags (--previous-version, --next-version, --release-date, --freeze-date) override YAML values.
-    4. If no YAML is found, all required values must come from CLI flags.
+    Resolution order, highest precedence first:
+
+    1. CLI flags (``--previous-version``, ``--next-version``, ``--release-date``, ``--freeze-date``).
+    2. A release config YAML: the file given by ``--release-config``, or
+       ``{galaxy_root}/doc/source/releases/{version}_release.yml`` if it exists.
+       The YAML is optional and so are all of its fields.
+    3. GitHub milestones, the source of truth for release dates and for the
+       surrounding release versions.
+    4. Locally derived fallbacks, used when GitHub is unreachable.
+
+    Values that cannot be resolved are left as ``None``; use :meth:`ReleaseConfig.require`
+    to assert on the ones a given command needs.
     """
-    yaml_config = _try_load_yaml_config(galaxy_root, release_version, release_config_path)
+    config = _try_load_yaml_config(galaxy_root, release_version, release_config_path)
+    if config is None:
+        config = ReleaseConfig(current_version=release_version)
 
-    if yaml_config is not None:
-        # Apply CLI overrides
-        if previous_version is not None:
-            yaml_config.previous_version = previous_version
-        if next_version is not None:
-            yaml_config.next_version = next_version
-        if release_date is not None:
-            yaml_config.release_date = release_date
-        if freeze_date is not None:
-            yaml_config.freeze_date = freeze_date
-        return yaml_config
+    # CLI flags override anything from the YAML.
+    if previous_version is not None:
+        config.previous_version = previous_version
+    if next_version is not None:
+        config.next_version = next_version
+    if release_date is not None:
+        config.release_date = release_date
+    if freeze_date is not None:
+        config.freeze_date = freeze_date
 
-    # No YAML found — build entirely from CLI flags
-    missing = []
-    if previous_version is None:
-        missing.append("--previous-version")
-    if release_date is None:
-        missing.append("--release-date")
-    if freeze_date is None:
-        missing.append("--freeze-date")
-    if missing:
-        raise ValueError(
-            f"No release config YAML found and missing required flag(s): {', '.join(missing)}. "
-            f"Provide a config YAML via --release-config or supply the flags directly."
-        )
-    return ReleaseConfig(
-        current_version=release_version,
-        previous_version=previous_version,
-        release_date=release_date,
-        freeze_date=freeze_date,
-        next_version=next_version,
-    )
+    if use_github:
+        _fill_from_milestones(config)
+    _fill_from_local_fallbacks(config, galaxy_root)
+    return config
+
+
+def milestone_due_dates(owner: str, repo: str) -> Dict[Version, Optional[datetime.date]]:
+    """Return a {version: due date} mapping of all milestones that are named after a version.
+
+    Milestones without a due date map to ``None``. Returns an empty mapping (with a
+    warning) if GitHub cannot be reached, so callers can fall back to local information.
+    """
+    try:
+        github_repo = github_client().get_repo(get_repo_name(owner, repo))
+        milestones = list(github_repo.get_milestones(state="all"))
+    except Exception as e:  # noqa: BLE001 - missing auth, rate limits and network errors are all recoverable here
+        click.echo(f"Warning: could not read milestones from {get_repo_name(owner, repo)}: {e}", err=True)
+        return {}
+    due_dates: Dict[Version, Optional[datetime.date]] = {}
+    for milestone in milestones:
+        try:
+            version = Version(milestone.title)
+        except InvalidVersion:
+            continue  # Milestones are not required to be named after a release.
+        due_dates[version] = milestone.due_on.date() if milestone.due_on else None
+    return due_dates
+
+
+def _fill_from_milestones(config: ReleaseConfig) -> None:
+    """Fill in release date and surrounding versions from the GitHub milestones."""
+    if config.release_date is not None and config.previous_version is not None and config.next_version is not None:
+        return  # Nothing left to look up, don't spend an API call.
+    due_dates = milestone_due_dates(config.owner, config.repo)
+    if not due_dates:
+        return
+    if config.release_date is None:
+        config.release_date = due_dates.get(config.current_version)
+    if config.previous_version is None:
+        earlier = [version for version in due_dates if version < config.current_version]
+        if earlier:
+            config.previous_version = max(earlier)
+    if config.next_version is None:
+        later = [version for version in due_dates if version > config.current_version]
+        if later:
+            config.next_version = min(later)
+
+
+def _fill_from_local_fallbacks(config: ReleaseConfig, galaxy_root: Path) -> None:
+    """Derive whatever is still missing without talking to GitHub."""
+    if config.next_version is None:
+        config.next_version = Version(f"{config.current_version.major}.{config.current_version.minor + 1}")
+    if config.previous_version is None:
+        config.previous_version = _previous_release_from_docs(galaxy_root, config.current_version)
+
+
+def _previous_release_from_docs(galaxy_root: Path, version: Version) -> Optional[Version]:
+    """Return the newest release documented in ``doc/source/releases`` that precedes ``version``."""
+    releases_path = galaxy_root / "doc" / "source" / "releases"
+    if not os.path.isdir(releases_path):
+        return None
+    documented = []
+    for filename in os.listdir(releases_path):
+        match = RELEASE_NOTES_FILENAME.match(filename)
+        if match:
+            documented.append(Version(match.group(1)))
+    earlier = [documented_version for documented_version in documented if documented_version < version]
+    return max(earlier) if earlier else None
 
 
 def _try_load_yaml_config(
@@ -82,68 +174,36 @@ def _try_load_yaml_config(
             raise FileNotFoundError(f"Release config not found: {release_config_path}")
         return _load_yaml_file(release_config_path, release_version)
 
-    default_path = galaxy_root / "doc" / "source" / "releases" / f"{release_version}_release.yml"
+    default_path = _default_config_path(galaxy_root, release_version)
     if not default_path.exists():
         return None
     return _load_yaml_file(default_path, release_version)
 
 
+def _default_config_path(galaxy_root: Path, release_version: Version) -> Path:
+    return galaxy_root / "doc" / "source" / "releases" / f"{release_version}_release.yml"
+
+
 def _load_yaml_file(path: Path, release_version: Version) -> ReleaseConfig:
-    """Load and validate a YAML release config file."""
-    with open(path) as f:
-        data = yaml.safe_load(f)
-    if not isinstance(data, dict):
-        raise ValueError(f"Release config must be a YAML mapping, got {type(data).__name__} in {path}")
-    required_fields = ["current-version", "previous-version", "freeze-date", "release-date"]
-    missing = [f for f in required_fields if f not in data]
-    if missing:
-        raise ValueError(
-            f"Missing required field(s) {', '.join(repr(f) for f in missing)} in {path}"
-        )
-    for field in required_fields:
-        if data[field] is None:
-            raise ValueError(f"Field '{field}' is present but has no value in {path}")
-    try:
-        current_version = Version(str(data["current-version"]))
-    except Exception as e:
-        raise ValueError(f"Invalid 'current-version' value {data['current-version']!r} in {path}: {e}")
-    try:
-        previous_version = Version(str(data["previous-version"]))
-    except Exception as e:
-        raise ValueError(
-            f"Invalid 'previous-version' value {data['previous-version']!r} in {path}: {e}"
-        )
-    next_version = None
-    if "next-version" in data:
-        if data["next-version"] is None:
-            raise ValueError(f"Field 'next-version' is present but has no value in {path}")
-        try:
-            next_version = Version(str(data["next-version"]))
-        except Exception as e:
-            raise ValueError(f"Invalid 'next-version' value {data['next-version']!r} in {path}: {e}")
-    try:
-        release_date = _parse_date(data["release-date"])
-    except Exception as e:
-        raise ValueError(f"Invalid 'release-date' value {data['release-date']!r} in {path}: {e}")
-    try:
-        freeze_date = _parse_date(data["freeze-date"])
-    except Exception as e:
-        raise ValueError(f"Invalid 'freeze-date' value {data['freeze-date']!r} in {path}: {e}")
-    if current_version != release_version:
+    """Load and validate a YAML release config file.
+
+    All fields are optional, but a field that is present must hold a valid value.
+    """
+    data = _read_yaml_mapping(path)
+    current_version = _optional_version(data, "current-version", path)
+    if current_version is not None and current_version != release_version:
         raise ValueError(
             f"'current-version' in config ({current_version}) does not match "
             f"release-version argument ({release_version})"
         )
-    owner = data.get("owner", "galaxyproject")
-    repo = data.get("repo", "galaxy")
     return ReleaseConfig(
-        current_version=current_version,
-        previous_version=previous_version,
-        release_date=release_date,
-        freeze_date=freeze_date,
-        next_version=next_version,
-        owner=owner,
-        repo=repo,
+        current_version=release_version,
+        previous_version=_optional_version(data, "previous-version", path),
+        next_version=_optional_version(data, "next-version", path),
+        release_date=_optional_date(data, "release-date", path),
+        freeze_date=_optional_date(data, "freeze-date", path),
+        owner=data.get("owner") or PROJECT_OWNER,
+        repo=data.get("repo") or PROJECT_NAME,
     )
 
 
@@ -151,7 +211,7 @@ def load_repo_owner(
     galaxy_root: Path,
     release_version: Version,
     release_config_path: Optional[Path] = None,
-) -> tuple:
+) -> Tuple[str, str]:
     """Load owner and repo from release config YAML.
 
     For point releases (e.g. 26.0.1), derives the major.minor version (26.0)
@@ -164,17 +224,50 @@ def load_repo_owner(
             raise FileNotFoundError(f"Release config not found: {release_config_path}")
         path = release_config_path
     else:
-        path = galaxy_root / "doc" / "source" / "releases" / f"{major_minor}_release.yml"
+        path = _default_config_path(galaxy_root, major_minor)
         if not path.exists():
-            return ("galaxyproject", "galaxy")
+            return (PROJECT_OWNER, PROJECT_NAME)
+    data = _read_yaml_mapping(path)
+    return (data.get("owner") or PROJECT_OWNER, data.get("repo") or PROJECT_NAME)
+
+
+def _read_yaml_mapping(path: Path) -> dict:
     with open(path) as f:
         data = yaml.safe_load(f)
+    if data is None:
+        return {}
     if not isinstance(data, dict):
         raise ValueError(f"Release config must be a YAML mapping, got {type(data).__name__} in {path}")
-    return (data.get("owner", "galaxyproject"), data.get("repo", "galaxy"))
+    return data
+
+
+def _optional_version(data: dict, field: str, path: Path) -> Optional[Version]:
+    if field not in data:
+        return None
+    value = data[field]
+    if value is None:
+        raise ValueError(f"Field '{field}' is present but has no value in {path}")
+    try:
+        return Version(str(value))
+    except InvalidVersion as e:
+        raise ValueError(f"Invalid '{field}' value {value!r} in {path}: {e}")
+
+
+def _optional_date(data: dict, field: str, path: Path) -> Optional[datetime.date]:
+    if field not in data:
+        return None
+    value = data[field]
+    if value is None:
+        raise ValueError(f"Field '{field}' is present but has no value in {path}")
+    try:
+        return _parse_date(value)
+    except ValueError as e:
+        raise ValueError(f"Invalid '{field}' value {value!r} in {path}: {e}")
 
 
 def _parse_date(value) -> datetime.date:
+    if isinstance(value, datetime.datetime):
+        return value.date()
     if isinstance(value, datetime.date):
         return value
     return datetime.datetime.strptime(str(value), "%Y-%m-%d").date()

--- a/galaxy_release_util/release_config.py
+++ b/galaxy_release_util/release_config.py
@@ -4,7 +4,10 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
+    Any,
     Dict,
+    Iterable,
+    Mapping,
     Optional,
 )
 
@@ -61,7 +64,6 @@ def load_release_config(
     freeze_date: Optional[datetime.date] = None,
     owner: str = PROJECT_OWNER,
     repo: str = PROJECT_NAME,
-    use_github: bool = True,
 ) -> ReleaseConfig:
     """Resolve release metadata for ``release_version``.
 
@@ -82,17 +84,32 @@ def load_release_config(
         owner=owner,
         repo=repo,
     )
-    if use_github:
-        _fill_from_milestones(config)
+    _fill_from_milestones(config)
     _fill_from_local_fallbacks(config, galaxy_root)
     return config
 
 
-def milestone_due_dates(owner: str, repo: str) -> Dict[Version, Optional[datetime.date]]:
-    """Return a {version: due date} mapping of all milestones that are named after a version.
+def due_dates_by_version(milestones: Iterable[Any]) -> Dict[Version, Optional[datetime.date]]:
+    """Map milestones named after a release version to their due dates.
 
-    Milestones without a due date map to ``None``. Returns an empty mapping (with a
-    warning) if GitHub cannot be reached, so callers can fall back to local information.
+    Titles that are not versions are skipped, since milestones are not required to
+    name a release. A milestone with no due date maps to ``None``.
+    """
+    due_dates: Dict[Version, Optional[datetime.date]] = {}
+    for milestone in milestones:
+        try:
+            version = Version(milestone.title)
+        except InvalidVersion:
+            continue
+        due_dates[version] = milestone.due_on.date() if milestone.due_on else None
+    return due_dates
+
+
+def milestone_due_dates(owner: str, repo: str) -> Dict[Version, Optional[datetime.date]]:
+    """Read the milestones of ``owner``/``repo`` as a {version: due date} mapping.
+
+    Returns an empty mapping (with a warning) if GitHub cannot be reached, so callers
+    can fall back to local information.
     """
     try:
         github_repo = github_client().get_repo(get_repo_name(owner, repo))
@@ -100,23 +117,15 @@ def milestone_due_dates(owner: str, repo: str) -> Dict[Version, Optional[datetim
     except Exception as e:  # noqa: BLE001 - missing auth, rate limits and network errors are all recoverable here
         click.echo(f"Warning: could not read milestones from {get_repo_name(owner, repo)}: {e}", err=True)
         return {}
-    due_dates: Dict[Version, Optional[datetime.date]] = {}
-    for milestone in milestones:
-        try:
-            version = Version(milestone.title)
-        except InvalidVersion:
-            continue  # Milestones are not required to be named after a release.
-        due_dates[version] = milestone.due_on.date() if milestone.due_on else None
-    return due_dates
+    return due_dates_by_version(milestones)
 
 
-def _fill_from_milestones(config: ReleaseConfig) -> None:
-    """Fill in release date and surrounding versions from the GitHub milestones."""
-    if config.release_date is not None and config.previous_version is not None and config.next_version is not None:
-        return  # Nothing left to look up, don't spend an API call.
-    due_dates = milestone_due_dates(config.owner, config.repo)
-    if not due_dates:
-        return
+def resolve_from_milestones(config: ReleaseConfig, due_dates: Mapping[Version, Optional[datetime.date]]) -> None:
+    """Fill gaps in ``config`` from a {version: due date} mapping, leaving set values alone.
+
+    The release date is the due date of the milestone naming the release; the
+    surrounding versions are its nearest neighbours.
+    """
     if config.release_date is None:
         config.release_date = due_dates.get(config.current_version)
     if config.previous_version is None:
@@ -127,6 +136,12 @@ def _fill_from_milestones(config: ReleaseConfig) -> None:
         later = [version for version in due_dates if version > config.current_version]
         if later:
             config.next_version = min(later)
+
+
+def _fill_from_milestones(config: ReleaseConfig) -> None:
+    if config.release_date is not None and config.previous_version is not None and config.next_version is not None:
+        return  # Nothing left to look up, don't spend an API call.
+    resolve_from_milestones(config, milestone_due_dates(config.owner, config.repo))
 
 
 def _fill_from_local_fallbacks(config: ReleaseConfig, galaxy_root: Path) -> None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ install_requires =
     docutils
     packaging
     PyGithub
-    PyYAML
     requests
     twine
 packages = find:

--- a/tests/test_bootstrap_history.py
+++ b/tests/test_bootstrap_history.py
@@ -1,5 +1,4 @@
 import datetime
-import os
 from pathlib import Path
 
 import pytest
@@ -17,7 +16,9 @@ from galaxy_release_util.bootstrap_history import (
     create_release_issue,
 )
 
-MILESTONES = {
+TEST_DATA = Path(".") / "tests" / "test_data"
+
+UPSTREAM_MILESTONES = {
     Version("98.1"): datetime.date(2098, 7, 15),
     Version("98.2"): datetime.date(2099, 1, 15),
     Version("99.0"): datetime.date(2099, 7, 15),
@@ -25,195 +26,152 @@ MILESTONES = {
 
 
 @pytest.fixture
-def release_files_dir():
-    return Path(".") / "tests" / "test_data"
+def expected():
+    """The release files as they should come out, keyed by name."""
+
+    def _read(name):
+        return (TEST_DATA / name).read_text()
+
+    return _read
 
 
 @pytest.fixture
-def announcement_file(release_files_dir):
-    with open(release_files_dir / "98.2_announce.rst") as f:
-        return f.read()
+def galaxy_root(tmp_path):
+    """A directory that satisfies the real verify_galaxy_root check."""
+    (tmp_path / "lib" / "galaxy" / "version").mkdir(parents=True)
+    (tmp_path / "lib" / "galaxy" / "version" / "__init__.py").write_text("")
+    (tmp_path / "doc" / "source" / "releases").mkdir(parents=True)
+    return tmp_path
 
 
 @pytest.fixture
-def user_announcement_file(release_files_dir):
-    with open(release_files_dir / "98.2_announce_user.rst") as f:
-        return f.read()
-
-
-@pytest.fixture
-def next_release_announcement_file(release_files_dir):
-    with open(release_files_dir / "99.0_announce.rst") as f:
-        return f.read()
-
-
-@pytest.fixture
-def prs_file(release_files_dir):
-    with open(release_files_dir / "98.2_prs.rst") as f:
-        return f.read()
+def releases_dir(galaxy_root):
+    return galaxy_root / "doc" / "source" / "releases"
 
 
 @pytest.fixture(autouse=True)
-def offline(monkeypatch):
-    """Never let the tests reach GitHub; milestones are stubbed per test instead."""
-    monkeypatch.setattr(bootstrap_history, "verify_galaxy_root", lambda x: None)
+def no_milestones(monkeypatch):
+    """Milestones come up empty unless a test says otherwise, so none of this hits GitHub."""
     monkeypatch.setattr(release_config, "milestone_due_dates", lambda owner, repo: {})
 
 
 @pytest.fixture
 def milestones(monkeypatch):
-    def _set(due_dates=MILESTONES):
-        monkeypatch.setattr(release_config, "milestone_due_dates", lambda owner, repo: due_dates)
+    """Publish milestones, either for every repository or per (owner, repo)."""
+
+    def _set(due_dates=UPSTREAM_MILESTONES, per_repo=None):
+        lookup = (lambda owner, repo: per_repo[(owner, repo)]) if per_repo else (lambda owner, repo: due_dates)
+        monkeypatch.setattr(release_config, "milestone_due_dates", lookup)
 
     return _set
 
 
-def test_create_changelog_from_milestones_only(
-    monkeypatch,
-    milestones,
-    announcement_file,
-    user_announcement_file,
-    prs_file,
-    next_release_announcement_file,
-):
-    """No config YAML, no date or version flags: the milestones supply everything."""
+@pytest.fixture
+def no_pr_scraping(monkeypatch):
+    """Skip the walk over every pull request GitHub has; the generated files are what matter."""
+    monkeypatch.setattr(bootstrap_history, "_load_prs", lambda *args, **kwargs: None)
+
+
+@pytest.mark.parametrize(
+    "extra_args",
+    [
+        pytest.param([], id="from-milestones"),
+        pytest.param(["--next-version", "99.0", "--release-date", "2099-01-15"], id="from-flags"),
+    ],
+)
+def test_create_changelog_writes_the_release_files(galaxy_root, releases_dir, milestones, no_pr_scraping, expected, extra_args):
     milestones()
-    monkeypatch.setattr(bootstrap_history, "_load_prs", lambda *args, **kwargs: None)
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        os.makedirs("doc/source/releases")
-        result = runner.invoke(create_changelog, ["98.2"])
-        assert result.exit_code == 0, result.output
+    result = CliRunner().invoke(create_changelog, ["98.2", "--galaxy-root", str(galaxy_root), *extra_args])
+    assert result.exit_code == 0, result.output
 
-        releases_path = Path("doc") / "source" / "releases"
-        with open(releases_path / "98.2_announce.rst") as f:
-            assert f.read() == announcement_file
-        with open(releases_path / "98.2_announce_user.rst") as f:
-            assert f.read() == user_announcement_file
-        with open(releases_path / "98.2_prs.rst") as f:
-            assert f.read() == prs_file
-        with open(releases_path / "99.0_announce.rst") as f:
-            assert f.read() == next_release_announcement_file
+    for name in ("98.2_announce.rst", "98.2_announce_user.rst", "98.2_prs.rst", "99.0_announce.rst"):
+        assert (releases_dir / name).read_text() == expected(name)
 
 
-def test_create_changelog_from_flags(monkeypatch, announcement_file, next_release_announcement_file):
-    """Flags still work when the milestones are unavailable."""
-    monkeypatch.setattr(bootstrap_history, "_load_prs", lambda *args, **kwargs: None)
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        os.makedirs("doc/source/releases")
-        result = runner.invoke(
-            create_changelog,
-            ["98.2", "--galaxy-root", ".", "--next-version", "99.0", "--release-date", "2099-01-15"],
-        )
-        assert result.exit_code == 0, result.output
-
-        releases_path = Path("doc") / "source" / "releases"
-        with open(releases_path / "98.2_announce.rst") as f:
-            assert f.read() == announcement_file
-        with open(releases_path / "99.0_announce.rst") as f:
-            assert f.read() == next_release_announcement_file
+def test_owner_and_repo_choose_which_milestones_are_read(galaxy_root, releases_dir, milestones, no_pr_scraping):
+    """A fork with a later 98.2 due date must produce a later date in the announcement."""
+    milestones(
+        per_repo={
+            ("galaxyproject", "galaxy"): UPSTREAM_MILESTONES,
+            ("mvdbeek", "galaxy-fork"): {Version("98.2"): datetime.date(2099, 6, 15), Version("99.0"): None},
+        }
+    )
+    result = CliRunner().invoke(
+        create_changelog,
+        ["98.2", "--galaxy-root", str(galaxy_root), "--owner", "mvdbeek", "--repo", "galaxy-fork"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "98.2 Galaxy Release (June 2099)" in (releases_dir / "98.2_announce.rst").read_text()
 
 
-def test_create_changelog_reads_milestones_of_the_given_repo(monkeypatch):
-    """--owner/--repo decide which milestones are consulted."""
-    seen = {}
-
-    def _record(owner, repo):
-        seen["target"] = (owner, repo)
-        return MILESTONES
-
-    monkeypatch.setattr(release_config, "milestone_due_dates", _record)
-    monkeypatch.setattr(bootstrap_history, "_load_prs", lambda *args, **kwargs: None)
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        os.makedirs("doc/source/releases")
-        result = runner.invoke(create_changelog, ["98.2", "--owner", "mvdbeek", "--repo", "galaxy-fork"])
-        assert result.exit_code == 0, result.output
-        assert seen["target"] == ("mvdbeek", "galaxy-fork")
+def test_create_changelog_reports_an_unresolvable_release_date(galaxy_root):
+    result = CliRunner().invoke(create_changelog, ["98.2", "--galaxy-root", str(galaxy_root)])
+    assert result.exit_code != 0
+    assert "--release-date" in result.output
+    assert "milestone titled '98.2'" in result.output
 
 
-def test_create_changelog_reports_unresolvable_release_date():
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        os.makedirs("doc/source/releases")
-        result = runner.invoke(create_changelog, ["98.2"])
-        assert result.exit_code != 0
-        assert "--release-date" in result.output
-        assert "milestone titled '98.2'" in result.output
-
-
-def test_create_changelog_does_not_ask_for_unused_values(milestones):
-    """previous-version and freeze-date are irrelevant here and must not be options."""
-    milestones()
-    runner = CliRunner()
-    result = runner.invoke(create_changelog, ["--help"])
+def test_create_changelog_does_not_ask_for_values_it_never_reads():
+    """The bug this guards: create-changelog demanded a previous version and a freeze date."""
+    result = CliRunner().invoke(create_changelog, ["--help"])
     assert result.exit_code == 0
     assert "--previous-version" not in result.output
     assert "--freeze-date" not in result.output
 
 
-def test_create_changelog_dry_run(milestones):
+def test_create_changelog_dry_run_writes_files_but_skips_github(galaxy_root, releases_dir, milestones):
     milestones()
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        os.makedirs("doc/source/releases")
-        result = runner.invoke(create_changelog, ["98.2", "--dry-run"])
-        assert result.exit_code == 0, result.output
-        assert "Dry run: skipping GitHub API call" in result.output
+    result = CliRunner().invoke(create_changelog, ["98.2", "--galaxy-root", str(galaxy_root), "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "Dry run: skipping GitHub API call" in result.output
+    assert (releases_dir / "98.2_announce.rst").exists()
 
 
-def test_check_blocking_prs_dry_run(milestones):
+def test_check_blocking_prs_dry_run_reports_the_resolved_date(galaxy_root, milestones):
     milestones()
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        os.makedirs("doc/source/releases")
-        result = runner.invoke(check_blocking_prs, ["98.2", "--dry-run"])
-        assert result.exit_code == 0, result.output
-        assert "Dry run: would check blocking PRs" in result.output
-        assert "2099-01-15" in result.output
+    result = CliRunner().invoke(check_blocking_prs, ["98.2", "--galaxy-root", str(galaxy_root), "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "2099-01-15" in result.output
 
 
-def test_check_blocking_issues_dry_run():
-    """Blocking issues are selected by milestone alone, so no dates are needed."""
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        os.makedirs("doc/source/releases")
-        result = runner.invoke(check_blocking_issues, ["98.2", "--dry-run"])
-        assert result.exit_code == 0, result.output
-        assert "Dry run: would check blocking issues" in result.output
+def test_check_blocking_issues_needs_no_dates(galaxy_root):
+    """Issues are selected by milestone alone, so the empty milestone lookup must not matter."""
+    result = CliRunner().invoke(check_blocking_issues, ["98.2", "--galaxy-root", str(galaxy_root), "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "Dry run: would check blocking issues" in result.output
 
 
-def test_create_release_issue_from_milestones(milestones):
-    """Only the freeze date, which no milestone records, has to be supplied."""
+def test_create_release_issue_needs_only_the_freeze_date(galaxy_root, milestones):
     milestones()
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        os.makedirs("doc/source/releases")
-        result = runner.invoke(create_release_issue, ["98.2", "--freeze-date", "2098-12-01", "--dry-run"])
-        assert result.exit_code == 0, result.output
-        assert "Freeze Release (on or around 2098-12-01)" in result.output
-        assert "`99.0` for next release" in result.output
+    result = CliRunner().invoke(
+        create_release_issue,
+        ["98.2", "--galaxy-root", str(galaxy_root), "--freeze-date", "2098-12-01", "--dry-run"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Freeze Release (on or around 2098-12-01)" in result.output
+    assert "`99.0` for next release" in result.output  # next version, from the milestones
+    assert "release_98.1" in result.output  # previous version, from the milestones
 
 
-def test_create_release_issue_rejects_invalid_next_version(milestones):
+def test_create_release_issue_rejects_a_next_version_that_precedes_the_release(galaxy_root, milestones):
     milestones()
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        os.makedirs("doc/source/releases")
-        result = runner.invoke(
-            create_release_issue,
-            ["98.2", "--next-version", "98.0", "--freeze-date", "2098-12-01", "--dry-run"],
-        )
-        assert result.exit_code != 0
-        assert "--next-version (98.0) must be greater than release version (98.2)" in result.output
+    result = CliRunner().invoke(
+        create_release_issue,
+        ["98.2", "--galaxy-root", str(galaxy_root), "--next-version", "98.0", "--freeze-date", "2098-12-01", "--dry-run"],
+    )
+    assert result.exit_code != 0
+    assert "--next-version (98.0) must be greater than release version (98.2)" in result.output
 
 
-def test_create_release_issue_reports_missing_freeze_date(milestones):
+def test_create_release_issue_reports_a_missing_freeze_date(galaxy_root, milestones):
     milestones()
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        os.makedirs("doc/source/releases")
-        result = runner.invoke(create_release_issue, ["98.2", "--dry-run"])
-        assert result.exit_code != 0
-        assert "--freeze-date" in result.output
+    result = CliRunner().invoke(create_release_issue, ["98.2", "--galaxy-root", str(galaxy_root), "--dry-run"])
+    assert result.exit_code != 0
+    assert "--freeze-date" in result.output
+
+
+def test_galaxy_root_is_verified(tmp_path):
+    """An empty directory is not a Galaxy checkout."""
+    result = CliRunner().invoke(create_changelog, ["98.2", "--galaxy-root", str(tmp_path)])
+    assert result.exit_code != 0
+    assert "Galaxy files not found" in str(result.exception)

--- a/tests/test_bootstrap_history.py
+++ b/tests/test_bootstrap_history.py
@@ -1,16 +1,27 @@
+import datetime
 import os
 from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
+from packaging.version import Version
 
-from galaxy_release_util import bootstrap_history
+from galaxy_release_util import (
+    bootstrap_history,
+    release_config,
+)
 from galaxy_release_util.bootstrap_history import (
     check_blocking_issues,
     check_blocking_prs,
     create_changelog,
     create_release_issue,
 )
+
+MILESTONES = {
+    Version("98.1"): datetime.date(2098, 7, 15),
+    Version("98.2"): datetime.date(2099, 1, 15),
+    Version("99.0"): datetime.date(2099, 7, 15),
+}
 
 
 @pytest.fixture
@@ -42,36 +53,39 @@ def prs_file(release_files_dir):
         return f.read()
 
 
-def test_create_changelog(
+@pytest.fixture(autouse=True)
+def offline(monkeypatch):
+    """Never let the tests reach GitHub; milestones are stubbed per test instead."""
+    monkeypatch.setattr(bootstrap_history, "verify_galaxy_root", lambda x: None)
+    monkeypatch.setattr(release_config, "milestone_due_dates", lambda owner, repo: {})
+
+
+@pytest.fixture
+def milestones(monkeypatch):
+    def _set(due_dates=MILESTONES):
+        monkeypatch.setattr(release_config, "milestone_due_dates", lambda owner, repo: due_dates)
+
+    return _set
+
+
+def test_create_changelog_from_milestones_only(
     monkeypatch,
+    milestones,
     announcement_file,
     user_announcement_file,
     prs_file,
     next_release_announcement_file,
 ):
-    monkeypatch.setattr(bootstrap_history, "verify_galaxy_root", lambda x: None)
-    monkeypatch.setattr(
-        bootstrap_history, "_load_prs", lambda *args, **kwargs: None
-    )  # We don't want to call github's API on test data.
+    """No config YAML, no date or version flags: the milestones supply everything."""
+    milestones()
+    monkeypatch.setattr(bootstrap_history, "_load_prs", lambda *args, **kwargs: None)
     runner = CliRunner()
     with runner.isolated_filesystem():
         os.makedirs("doc/source/releases")
-        # Write a release config YAML
-        config_content = (
-            "current-version: '98.2'\n"
-            "previous-version: '98.1'\n"
-            "release-date: '2099-01-15'\n"
-            "freeze-date: '2099-01-01'\n"
-        )
-        config_path = Path("doc/source/releases/release_98.2.yml")
-        config_path.write_text(config_content)
-        result = runner.invoke(
-            create_changelog, ["98.2", "--galaxy-root", ".", "--next-version", "99.0"]
-        )  # version 98.2 to be released on January 15, 2099
+        result = runner.invoke(create_changelog, ["98.2"])
         assert result.exit_code == 0, result.output
 
         releases_path = Path("doc") / "source" / "releases"
-
         with open(releases_path / "98.2_announce.rst") as f:
             assert f.read() == announcement_file
         with open(releases_path / "98.2_announce_user.rst") as f:
@@ -82,99 +96,120 @@ def test_create_changelog(
             assert f.read() == next_release_announcement_file
 
 
-def test_create_changelog_dry_run(monkeypatch):
-    monkeypatch.setattr(bootstrap_history, "verify_galaxy_root", lambda x: None)
+def test_create_changelog_from_flags(monkeypatch, announcement_file, next_release_announcement_file):
+    """Flags still work when the milestones are unavailable."""
+    monkeypatch.setattr(bootstrap_history, "_load_prs", lambda *args, **kwargs: None)
     runner = CliRunner()
     with runner.isolated_filesystem():
         os.makedirs("doc/source/releases")
-        config_content = (
-            "current-version: '98.2'\n"
-            "previous-version: '98.1'\n"
-            "release-date: '2099-01-15'\n"
-            "freeze-date: '2099-01-01'\n"
-        )
-        config_path = Path("doc/source/releases/release_98.2.yml")
-        config_path.write_text(config_content)
         result = runner.invoke(
-            create_changelog, ["98.2", "--galaxy-root", ".", "--next-version", "99.0", "--dry-run"]
+            create_changelog,
+            ["98.2", "--galaxy-root", ".", "--next-version", "99.0", "--release-date", "2099-01-15"],
         )
+        assert result.exit_code == 0, result.output
+
+        releases_path = Path("doc") / "source" / "releases"
+        with open(releases_path / "98.2_announce.rst") as f:
+            assert f.read() == announcement_file
+        with open(releases_path / "99.0_announce.rst") as f:
+            assert f.read() == next_release_announcement_file
+
+
+def test_create_changelog_from_config_yaml(monkeypatch, announcement_file):
+    monkeypatch.setattr(bootstrap_history, "_load_prs", lambda *args, **kwargs: None)
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        os.makedirs("doc/source/releases")
+        Path("doc/source/releases/98.2_release.yml").write_text(
+            "current-version: '98.2'\nrelease-date: '2099-01-15'\nnext-version: '99.0'\n"
+        )
+        result = runner.invoke(create_changelog, ["98.2"])
+        assert result.exit_code == 0, result.output
+        with open(Path("doc") / "source" / "releases" / "98.2_announce.rst") as f:
+            assert f.read() == announcement_file
+
+
+def test_create_changelog_reports_unresolvable_release_date():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        os.makedirs("doc/source/releases")
+        result = runner.invoke(create_changelog, ["98.2"])
+        assert result.exit_code != 0
+        assert "--release-date" in result.output
+        assert "milestone titled '98.2'" in result.output
+
+
+def test_create_changelog_does_not_ask_for_unused_values(milestones):
+    """previous-version and freeze-date are irrelevant here and must not be options."""
+    milestones()
+    runner = CliRunner()
+    result = runner.invoke(create_changelog, ["--help"])
+    assert result.exit_code == 0
+    assert "--previous-version" not in result.output
+    assert "--freeze-date" not in result.output
+
+
+def test_create_changelog_dry_run(milestones):
+    milestones()
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        os.makedirs("doc/source/releases")
+        result = runner.invoke(create_changelog, ["98.2", "--dry-run"])
         assert result.exit_code == 0, result.output
         assert "Dry run: skipping GitHub API call" in result.output
 
 
-def test_check_blocking_prs_dry_run(monkeypatch):
-    monkeypatch.setattr(bootstrap_history, "verify_galaxy_root", lambda x: None)
+def test_check_blocking_prs_dry_run(milestones):
+    milestones()
     runner = CliRunner()
     with runner.isolated_filesystem():
         os.makedirs("doc/source/releases")
-        config_content = (
-            "current-version: '98.2'\n"
-            "previous-version: '98.1'\n"
-            "release-date: '2099-01-15'\n"
-            "freeze-date: '2099-01-01'\n"
-        )
-        config_path = Path("doc/source/releases/release_98.2.yml")
-        config_path.write_text(config_content)
-        result = runner.invoke(
-            check_blocking_prs, ["98.2", "--galaxy-root", ".", "--dry-run"]
-        )
+        result = runner.invoke(check_blocking_prs, ["98.2", "--dry-run"])
         assert result.exit_code == 0, result.output
         assert "Dry run: would check blocking PRs" in result.output
+        assert "2099-01-15" in result.output
 
 
-def test_check_blocking_issues_dry_run(monkeypatch):
-    monkeypatch.setattr(bootstrap_history, "verify_galaxy_root", lambda x: None)
+def test_check_blocking_issues_dry_run():
+    """Blocking issues are selected by milestone alone, so no dates are needed."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         os.makedirs("doc/source/releases")
-        config_content = (
-            "current-version: '98.2'\n"
-            "previous-version: '98.1'\n"
-            "release-date: '2099-01-15'\n"
-            "freeze-date: '2099-01-01'\n"
-        )
-        config_path = Path("doc/source/releases/release_98.2.yml")
-        config_path.write_text(config_content)
-        result = runner.invoke(
-            check_blocking_issues, ["98.2", "--galaxy-root", ".", "--dry-run"]
-        )
+        result = runner.invoke(check_blocking_issues, ["98.2", "--dry-run"])
         assert result.exit_code == 0, result.output
         assert "Dry run: would check blocking issues" in result.output
 
 
-def test_create_release_issue_rejects_invalid_next_version(monkeypatch):
-    monkeypatch.setattr(bootstrap_history, "verify_galaxy_root", lambda x: None)
+def test_create_release_issue_from_milestones(milestones):
+    """Only the freeze date, which no milestone records, has to be supplied."""
+    milestones()
     runner = CliRunner()
     with runner.isolated_filesystem():
         os.makedirs("doc/source/releases")
-        config_content = (
-            "current-version: '98.2'\n"
-            "previous-version: '98.1'\n"
-            "release-date: '2099-01-15'\n"
-            "freeze-date: '2099-01-01'\n"
-        )
-        Path("doc/source/releases/release_98.2.yml").write_text(config_content)
+        result = runner.invoke(create_release_issue, ["98.2", "--freeze-date", "2098-12-01", "--dry-run"])
+        assert result.exit_code == 0, result.output
+        assert "Freeze Release (on or around 2098-12-01)" in result.output
+        assert "`99.0` for next release" in result.output
+
+
+def test_create_release_issue_rejects_invalid_next_version(milestones):
+    milestones()
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        os.makedirs("doc/source/releases")
         result = runner.invoke(
-            create_release_issue, ["98.2", "--galaxy-root", ".", "--next-version", "98.0", "--dry-run"]
+            create_release_issue,
+            ["98.2", "--next-version", "98.0", "--freeze-date", "2098-12-01", "--dry-run"],
         )
         assert result.exit_code != 0
         assert "--next-version (98.0) must be greater than release version (98.2)" in result.output
 
 
-def test_create_release_issue_rejects_missing_freeze_date(monkeypatch):
-    monkeypatch.setattr(bootstrap_history, "verify_galaxy_root", lambda x: None)
+def test_create_release_issue_reports_missing_freeze_date(milestones):
+    milestones()
     runner = CliRunner()
     with runner.isolated_filesystem():
         os.makedirs("doc/source/releases")
-        config_content = (
-            "current-version: '98.2'\n"
-            "previous-version: '98.1'\n"
-            "release-date: '2099-01-15'\n"
-        )
-        Path("doc/source/releases/release_98.2.yml").write_text(config_content)
-        result = runner.invoke(
-            create_release_issue, ["98.2", "--galaxy-root", ".", "--next-version", "99.0", "--dry-run"]
-        )
+        result = runner.invoke(create_release_issue, ["98.2", "--dry-run"])
         assert result.exit_code != 0
-        assert "Missing required field" in str(result.exception)
-        assert "freeze-date" in str(result.exception)
+        assert "--freeze-date" in result.output

--- a/tests/test_bootstrap_history.py
+++ b/tests/test_bootstrap_history.py
@@ -115,18 +115,22 @@ def test_create_changelog_from_flags(monkeypatch, announcement_file, next_releas
             assert f.read() == next_release_announcement_file
 
 
-def test_create_changelog_from_config_yaml(monkeypatch, announcement_file):
+def test_create_changelog_reads_milestones_of_the_given_repo(monkeypatch):
+    """--owner/--repo decide which milestones are consulted."""
+    seen = {}
+
+    def _record(owner, repo):
+        seen["target"] = (owner, repo)
+        return MILESTONES
+
+    monkeypatch.setattr(release_config, "milestone_due_dates", _record)
     monkeypatch.setattr(bootstrap_history, "_load_prs", lambda *args, **kwargs: None)
     runner = CliRunner()
     with runner.isolated_filesystem():
         os.makedirs("doc/source/releases")
-        Path("doc/source/releases/98.2_release.yml").write_text(
-            "current-version: '98.2'\nrelease-date: '2099-01-15'\nnext-version: '99.0'\n"
-        )
-        result = runner.invoke(create_changelog, ["98.2"])
+        result = runner.invoke(create_changelog, ["98.2", "--owner", "mvdbeek", "--repo", "galaxy-fork"])
         assert result.exit_code == 0, result.output
-        with open(Path("doc") / "source" / "releases" / "98.2_announce.rst") as f:
-            assert f.read() == announcement_file
+        assert seen["target"] == ("mvdbeek", "galaxy-fork")
 
 
 def test_create_changelog_reports_unresolvable_release_date():

--- a/tests/test_data/release_98.2.yml
+++ b/tests/test_data/release_98.2.yml
@@ -1,4 +1,0 @@
-current-version: "98.2"
-previous-version: "98.1"
-freeze-date: "2099-01-01"
-release-date: "2099-01-15"

--- a/tests/test_release_config.py
+++ b/tests/test_release_config.py
@@ -1,4 +1,5 @@
 import datetime
+from types import SimpleNamespace
 
 import pytest
 from packaging.version import Version
@@ -6,187 +7,146 @@ from packaging.version import Version
 from galaxy_release_util import release_config
 from galaxy_release_util.release_config import (
     ReleaseConfig,
+    due_dates_by_version,
     load_release_config,
+    resolve_from_milestones,
 )
 
-# Captured before the autouse stub below replaces it.
-real_milestone_due_dates = release_config.milestone_due_dates
-
+# The 26.x milestones as GitHub reports them.
 GALAXY_MILESTONES = {
     Version("26.0"): datetime.date(2026, 1, 27),
-    Version("26.1"): datetime.date(2026, 5, 20),
+    Version("26.1"): datetime.date(2026, 7, 30),
     Version("26.2"): datetime.date(2026, 10, 14),
 }
 
 
-@pytest.fixture
-def releases_dir(tmp_path):
-    path = tmp_path / "doc" / "source" / "releases"
-    path.mkdir(parents=True)
-    return path
+def _config(**kwargs) -> ReleaseConfig:
+    return ReleaseConfig(current_version=Version("26.1"), **kwargs)
 
 
-@pytest.fixture(autouse=True)
-def no_github(monkeypatch):
-    """Fail loudly if a test reaches for GitHub without saying so."""
-
-    def _explode(owner, repo):
-        raise AssertionError("test unexpectedly queried GitHub milestones")
-
-    monkeypatch.setattr(release_config, "milestone_due_dates", _explode)
+def _milestone(title, due_on=None):
+    """Stand-in for a PyGithub Milestone, which is a title and a due date to us."""
+    return SimpleNamespace(title=title, due_on=due_on)
 
 
-@pytest.fixture
-def milestones(monkeypatch):
-    """Stub the GitHub milestone lookup with a fixed {version: due date} mapping."""
-
-    def _set(due_dates=GALAXY_MILESTONES):
-        monkeypatch.setattr(release_config, "milestone_due_dates", lambda owner, repo: due_dates)
-
-    return _set
+# Reading milestones off GitHub -------------------------------------------------
 
 
-def test_everything_comes_from_the_milestones(tmp_path, milestones):
-    """The common case: nothing passed, everything read off the milestones."""
-    milestones()
-    config = load_release_config(tmp_path, Version("26.1"))
-    assert config.release_date == datetime.date(2026, 5, 20)
-    assert config.previous_version == Version("26.0")
-    assert config.next_version == Version("26.2")
+def test_milestone_titles_become_versions_and_due_dates_become_dates():
+    milestones = [_milestone("26.1", datetime.datetime(2026, 7, 30))]
+    assert due_dates_by_version(milestones) == {Version("26.1"): datetime.date(2026, 7, 30)}
 
 
-def test_flags_win_over_milestones(tmp_path, milestones):
-    milestones()
-    config = load_release_config(
-        tmp_path,
-        Version("26.1"),
-        release_date=datetime.date(2026, 6, 1),
-        next_version=Version("27.0"),
-        previous_version=Version("25.1"),
-        freeze_date=datetime.date(2026, 4, 15),
-    )
-    assert config.release_date == datetime.date(2026, 6, 1)
-    assert config.next_version == Version("27.0")
-    assert config.previous_version == Version("25.1")
-    assert config.freeze_date == datetime.date(2026, 4, 15)
+def test_milestones_not_named_after_a_release_are_skipped():
+    milestones = [_milestone("Backlog"), _milestone("sprint 4"), _milestone("26.1")]
+    assert list(due_dates_by_version(milestones)) == [Version("26.1")]
 
 
-def test_milestones_fill_only_the_gaps(tmp_path, milestones):
-    milestones()
-    config = load_release_config(tmp_path, Version("26.1"), next_version=Version("27.0"))
-    assert config.next_version == Version("27.0")
-    assert config.release_date == datetime.date(2026, 5, 20)
-
-
-def test_no_api_call_when_flags_cover_everything(tmp_path):
-    """The autouse guard would fire if the milestones were consulted here."""
-    config = load_release_config(
-        tmp_path,
-        Version("26.1"),
-        previous_version=Version("26.0"),
-        next_version=Version("26.2"),
-        release_date=datetime.date(2026, 5, 20),
-    )
-    assert config.release_date == datetime.date(2026, 5, 20)
-
-
-def test_milestone_without_due_date_leaves_release_date_unknown(tmp_path, milestones):
-    milestones({Version("26.1"): None})
-    config = load_release_config(tmp_path, Version("26.1"))
-    assert config.release_date is None
-
-
-def test_owner_and_repo_select_the_milestones(tmp_path, monkeypatch):
-    seen = {}
-
-    def _record(owner, repo):
-        seen["target"] = (owner, repo)
-        return {}
-
-    monkeypatch.setattr(release_config, "milestone_due_dates", _record)
-    config = load_release_config(tmp_path, Version("26.1"), owner="mvdbeek", repo="galaxy-fork")
-    assert seen["target"] == ("mvdbeek", "galaxy-fork")
-    assert (config.owner, config.repo) == ("mvdbeek", "galaxy-fork")
-
-
-def test_owner_and_repo_default_to_galaxy(tmp_path, milestones):
-    milestones()
-    config = load_release_config(tmp_path, Version("26.1"))
-    assert (config.owner, config.repo) == ("galaxyproject", "galaxy")
-
-
-def test_falls_back_to_release_notes_when_github_is_unavailable(tmp_path, releases_dir, milestones):
-    milestones({})
-    for documented in ("26.0.rst", "25.1.rst", "24.2.rst"):
-        (releases_dir / documented).write_text("")
-    config = load_release_config(tmp_path, Version("26.1"))
-    assert config.previous_version == Version("26.0")
-    assert config.next_version == Version("26.2")
-    assert config.release_date is None
-
-
-def test_previous_version_unknown_without_docs_or_milestones(tmp_path, milestones):
-    milestones({})
-    config = load_release_config(tmp_path, Version("26.1"))
-    assert config.previous_version is None
-
-
-def test_require_reports_missing_values(tmp_path, milestones):
-    milestones({})
-    config = load_release_config(tmp_path, Version("26.1"))
-    with pytest.raises(ValueError, match=r"--release-date, --freeze-date"):
-        config.require("release_date", "freeze_date")
-
-
-def test_require_error_names_the_repository(tmp_path, milestones):
-    milestones({})
-    config = load_release_config(tmp_path, Version("26.1"), owner="mvdbeek", repo="galaxy-fork")
-    with pytest.raises(ValueError, match="mvdbeek/galaxy-fork"):
-        config.require("release_date")
-
-
-def test_require_passes_when_values_are_known():
-    config = ReleaseConfig(current_version=Version("26.1"), release_date=datetime.date(2026, 5, 20))
-    config.require("release_date")
-
-
-class _FakeMilestone:
-    def __init__(self, title, due_on):
-        self.title = title
-        self.due_on = due_on
-
-
-class _FakeRepo:
-    def __init__(self, milestones):
-        self._milestones = milestones
-
-    def get_milestones(self, state):
-        return self._milestones
-
-
-class _FakeGithub:
-    def __init__(self, repo):
-        self._repo = repo
-
-    def get_repo(self, name):
-        return self._repo
-
-
-def test_unparsable_milestone_titles_are_ignored(monkeypatch):
-    repo = _FakeRepo(
-        [
-            _FakeMilestone("Backlog", None),
-            _FakeMilestone("26.1", datetime.datetime(2026, 5, 20)),
-        ]
-    )
-    monkeypatch.setattr(release_config, "github_client", lambda: _FakeGithub(repo))
-    assert real_milestone_due_dates("galaxyproject", "galaxy") == {Version("26.1"): datetime.date(2026, 5, 20)}
+def test_milestone_without_a_due_date_maps_to_none():
+    assert due_dates_by_version([_milestone("26.1")]) == {Version("26.1"): None}
 
 
 def test_milestone_lookup_failure_is_not_fatal(monkeypatch, capsys):
+    """A missing token must degrade to local resolution, not abort the release."""
+
     def _raise():
         raise RuntimeError("no GitHub auth configured")
 
     monkeypatch.setattr(release_config, "github_client", _raise)
-    assert real_milestone_due_dates("galaxyproject", "galaxy") == {}
+    assert release_config.milestone_due_dates("galaxyproject", "galaxy") == {}
     assert "Warning: could not read milestones" in capsys.readouterr().err
+
+
+# Resolving a release against the milestones ------------------------------------
+
+
+def test_release_date_is_the_due_date_of_its_own_milestone():
+    config = _config()
+    resolve_from_milestones(config, GALAXY_MILESTONES)
+    assert config.release_date == datetime.date(2026, 7, 30)
+
+
+def test_surrounding_versions_are_the_neighbouring_milestones():
+    config = _config()
+    resolve_from_milestones(config, {Version(v): None for v in ("24.0", "25.1", "26.0", "26.2", "27.0")})
+    assert config.previous_version == Version("26.0")
+    assert config.next_version == Version("26.2")
+
+
+def test_values_already_set_survive_the_milestones():
+    config = _config(release_date=datetime.date(2026, 6, 1), next_version=Version("27.0"))
+    resolve_from_milestones(config, GALAXY_MILESTONES)
+    assert config.release_date == datetime.date(2026, 6, 1)
+    assert config.next_version == Version("27.0")
+    assert config.previous_version == Version("26.0")  # the remaining gap is still filled
+
+
+def test_release_date_stays_unknown_when_its_milestone_has_no_due_date():
+    config = _config()
+    resolve_from_milestones(config, {Version("26.1"): None, Version("26.0"): datetime.date(2026, 1, 27)})
+    assert config.release_date is None
+    assert config.previous_version == Version("26.0")
+
+
+def test_nothing_is_invented_when_there_are_no_milestones():
+    config = _config()
+    resolve_from_milestones(config, {})
+    assert (config.release_date, config.previous_version, config.next_version) == (None, None, None)
+
+
+# What a command is allowed to demand -------------------------------------------
+
+
+def test_require_names_the_missing_flags_and_the_repository():
+    config = _config(owner="mvdbeek", repo="galaxy-fork")
+    with pytest.raises(ValueError) as excinfo:
+        config.require("release_date", "freeze_date")
+    assert "--release-date, --freeze-date" in str(excinfo.value)
+    assert "mvdbeek/galaxy-fork" in str(excinfo.value)
+
+
+def test_require_accepts_a_resolved_value():
+    _config(release_date=datetime.date(2026, 7, 30)).require("release_date")
+
+
+# Falling back when GitHub is unreachable ---------------------------------------
+
+
+@pytest.fixture
+def offline(monkeypatch):
+    """Every milestone lookup comes up empty, as it would with no network."""
+    monkeypatch.setattr(release_config, "milestone_due_dates", lambda owner, repo: {})
+
+
+def test_previous_version_falls_back_to_the_documented_releases(tmp_path, offline):
+    releases = tmp_path / "doc" / "source" / "releases"
+    releases.mkdir(parents=True)
+    for name in ("24.2.rst", "25.1.rst", "26.0.rst", "26.1_announce.rst", "index.rst"):
+        (releases / name).write_text("")
+    config = load_release_config(tmp_path, Version("26.1"))
+    assert config.previous_version == Version("26.0")
+
+
+def test_next_version_falls_back_to_the_next_minor(tmp_path, offline):
+    config = load_release_config(tmp_path, Version("26.1"))
+    assert config.next_version == Version("26.2")
+
+
+def test_release_date_has_no_fallback(tmp_path, offline):
+    """Nothing on disk records it, so the command must ask for it rather than guess."""
+    config = load_release_config(tmp_path, Version("26.1"))
+    assert config.release_date is None
+
+
+def test_milestones_are_not_read_when_the_flags_cover_everything(tmp_path, monkeypatch):
+    def _explode(owner, repo):
+        raise AssertionError("milestones were read despite every value being supplied")
+
+    monkeypatch.setattr(release_config, "milestone_due_dates", _explode)
+    load_release_config(
+        tmp_path,
+        Version("26.1"),
+        previous_version=Version("26.0"),
+        next_version=Version("26.2"),
+        release_date=datetime.date(2026, 7, 30),
+    )

--- a/tests/test_release_config.py
+++ b/tests/test_release_config.py
@@ -1,5 +1,4 @@
 import datetime
-from pathlib import Path
 
 import pytest
 from packaging.version import Version
@@ -8,25 +7,23 @@ from galaxy_release_util import release_config
 from galaxy_release_util.release_config import (
     ReleaseConfig,
     load_release_config,
-    load_repo_owner,
 )
 
 # Captured before the autouse stub below replaces it.
 real_milestone_due_dates = release_config.milestone_due_dates
 
-FULL_CONFIG = (
-    "current-version: '98.2'\n"
-    "previous-version: '98.1'\n"
-    "freeze-date: '2099-01-01'\n"
-    "release-date: '2099-01-15'\n"
-)
+GALAXY_MILESTONES = {
+    Version("26.0"): datetime.date(2026, 1, 27),
+    Version("26.1"): datetime.date(2026, 5, 20),
+    Version("26.2"): datetime.date(2026, 10, 14),
+}
 
 
 @pytest.fixture
-def config_dir(tmp_path):
-    releases_dir = tmp_path / "doc" / "source" / "releases"
-    releases_dir.mkdir(parents=True)
-    return releases_dir
+def releases_dir(tmp_path):
+    path = tmp_path / "doc" / "source" / "releases"
+    path.mkdir(parents=True)
+    return path
 
 
 @pytest.fixture(autouse=True)
@@ -43,113 +40,114 @@ def no_github(monkeypatch):
 def milestones(monkeypatch):
     """Stub the GitHub milestone lookup with a fixed {version: due date} mapping."""
 
-    def _set(due_dates):
+    def _set(due_dates=GALAXY_MILESTONES):
         monkeypatch.setattr(release_config, "milestone_due_dates", lambda owner, repo: due_dates)
 
     return _set
 
 
-def _write_config(config_dir, filename, content):
-    path = config_dir / filename
-    path.write_text(content)
-    return path
-
-
-def test_load_release_config_default_path(tmp_path, config_dir):
-    _write_config(config_dir, "98.2_release.yml", FULL_CONFIG)
-    config = load_release_config(tmp_path, Version("98.2"), use_github=False)
-    assert config.current_version == Version("98.2")
-    assert config.previous_version == Version("98.1")
-    assert config.release_date == datetime.date(2099, 1, 15)
-    assert config.freeze_date == datetime.date(2099, 1, 1)
-    assert config.owner == "galaxyproject"
-    assert config.repo == "galaxy"
-
-
-def test_load_release_config_explicit_path(tmp_path, config_dir):
-    path = _write_config(
-        config_dir,
-        "custom.yml",
-        "current-version: '25.0'\nprevious-version: '24.2'\nrelease-date: '2025-07-01'\n"
-        "freeze-date: '2025-06-01'\nowner: myorg\nrepo: myrepo\n",
-    )
-    config = load_release_config(tmp_path, Version("25.0"), release_config_path=path, use_github=False)
-    assert config.current_version == Version("25.0")
-    assert config.previous_version == Version("24.2")
-    assert config.release_date == datetime.date(2025, 7, 1)
-    assert config.freeze_date == datetime.date(2025, 6, 1)
-    assert config.owner == "myorg"
-    assert config.repo == "myrepo"
-
-
-def test_load_release_config_explicit_path_missing(tmp_path):
-    with pytest.raises(FileNotFoundError):
-        load_release_config(tmp_path, Version("99.0"), release_config_path=tmp_path / "nonexistent.yml")
-
-
-def test_load_release_config_cli_overrides_yaml(tmp_path, config_dir):
-    _write_config(config_dir, "98.2_release.yml", FULL_CONFIG)
-    config = load_release_config(
-        tmp_path,
-        Version("98.2"),
-        next_version=Version("99.5"),
-        release_date=datetime.date(2099, 6, 1),
-        use_github=False,
-    )
-    assert config.next_version == Version("99.5")
-    assert config.release_date == datetime.date(2099, 6, 1)
-    # Non-overridden values from YAML
-    assert config.previous_version == Version("98.1")
-
-
-def test_load_release_config_needs_no_yaml_or_flags(tmp_path, milestones):
-    """The common case: nothing configured locally, everything read off the milestones."""
-    milestones(
-        {
-            Version("26.0"): datetime.date(2026, 1, 27),
-            Version("26.1"): datetime.date(2026, 5, 20),
-            Version("26.2"): datetime.date(2026, 10, 14),
-        }
-    )
+def test_everything_comes_from_the_milestones(tmp_path, milestones):
+    """The common case: nothing passed, everything read off the milestones."""
+    milestones()
     config = load_release_config(tmp_path, Version("26.1"))
     assert config.release_date == datetime.date(2026, 5, 20)
     assert config.previous_version == Version("26.0")
     assert config.next_version == Version("26.2")
 
 
-def test_cli_flags_win_over_milestones(tmp_path, milestones):
-    milestones({Version("26.1"): datetime.date(2026, 5, 20), Version("26.2"): datetime.date(2026, 10, 14)})
+def test_flags_win_over_milestones(tmp_path, milestones):
+    milestones()
     config = load_release_config(
         tmp_path,
         Version("26.1"),
         release_date=datetime.date(2026, 6, 1),
         next_version=Version("27.0"),
+        previous_version=Version("25.1"),
+        freeze_date=datetime.date(2026, 4, 15),
     )
     assert config.release_date == datetime.date(2026, 6, 1)
     assert config.next_version == Version("27.0")
+    assert config.previous_version == Version("25.1")
+    assert config.freeze_date == datetime.date(2026, 4, 15)
 
 
-def test_yaml_wins_over_milestones(tmp_path, config_dir, milestones):
-    _write_config(config_dir, "98.2_release.yml", FULL_CONFIG)
-    milestones({Version("98.2"): datetime.date(2050, 1, 1)})
-    config = load_release_config(tmp_path, Version("98.2"))
-    assert config.release_date == datetime.date(2099, 1, 15)
+def test_milestones_fill_only_the_gaps(tmp_path, milestones):
+    milestones()
+    config = load_release_config(tmp_path, Version("26.1"), next_version=Version("27.0"))
+    assert config.next_version == Version("27.0")
+    assert config.release_date == datetime.date(2026, 5, 20)
 
 
-def test_milestone_fills_gaps_left_by_yaml(tmp_path, config_dir, milestones):
-    """A YAML without a release date still gets one from the milestone."""
-    _write_config(config_dir, "98.2_release.yml", "previous-version: '98.1'\n")
-    milestones({Version("98.2"): datetime.date(2050, 1, 1), Version("99.0"): None})
-    config = load_release_config(tmp_path, Version("98.2"))
-    assert config.previous_version == Version("98.1")
-    assert config.release_date == datetime.date(2050, 1, 1)
-    assert config.next_version == Version("99.0")
+def test_no_api_call_when_flags_cover_everything(tmp_path):
+    """The autouse guard would fire if the milestones were consulted here."""
+    config = load_release_config(
+        tmp_path,
+        Version("26.1"),
+        previous_version=Version("26.0"),
+        next_version=Version("26.2"),
+        release_date=datetime.date(2026, 5, 20),
+    )
+    assert config.release_date == datetime.date(2026, 5, 20)
 
 
 def test_milestone_without_due_date_leaves_release_date_unknown(tmp_path, milestones):
-    milestones({Version("98.2"): None})
-    config = load_release_config(tmp_path, Version("98.2"))
+    milestones({Version("26.1"): None})
+    config = load_release_config(tmp_path, Version("26.1"))
     assert config.release_date is None
+
+
+def test_owner_and_repo_select_the_milestones(tmp_path, monkeypatch):
+    seen = {}
+
+    def _record(owner, repo):
+        seen["target"] = (owner, repo)
+        return {}
+
+    monkeypatch.setattr(release_config, "milestone_due_dates", _record)
+    config = load_release_config(tmp_path, Version("26.1"), owner="mvdbeek", repo="galaxy-fork")
+    assert seen["target"] == ("mvdbeek", "galaxy-fork")
+    assert (config.owner, config.repo) == ("mvdbeek", "galaxy-fork")
+
+
+def test_owner_and_repo_default_to_galaxy(tmp_path, milestones):
+    milestones()
+    config = load_release_config(tmp_path, Version("26.1"))
+    assert (config.owner, config.repo) == ("galaxyproject", "galaxy")
+
+
+def test_falls_back_to_release_notes_when_github_is_unavailable(tmp_path, releases_dir, milestones):
+    milestones({})
+    for documented in ("26.0.rst", "25.1.rst", "24.2.rst"):
+        (releases_dir / documented).write_text("")
+    config = load_release_config(tmp_path, Version("26.1"))
+    assert config.previous_version == Version("26.0")
+    assert config.next_version == Version("26.2")
+    assert config.release_date is None
+
+
+def test_previous_version_unknown_without_docs_or_milestones(tmp_path, milestones):
+    milestones({})
+    config = load_release_config(tmp_path, Version("26.1"))
+    assert config.previous_version is None
+
+
+def test_require_reports_missing_values(tmp_path, milestones):
+    milestones({})
+    config = load_release_config(tmp_path, Version("26.1"))
+    with pytest.raises(ValueError, match=r"--release-date, --freeze-date"):
+        config.require("release_date", "freeze_date")
+
+
+def test_require_error_names_the_repository(tmp_path, milestones):
+    milestones({})
+    config = load_release_config(tmp_path, Version("26.1"), owner="mvdbeek", repo="galaxy-fork")
+    with pytest.raises(ValueError, match="mvdbeek/galaxy-fork"):
+        config.require("release_date")
+
+
+def test_require_passes_when_values_are_known():
+    config = ReleaseConfig(current_version=Version("26.1"), release_date=datetime.date(2026, 5, 20))
+    config.require("release_date")
 
 
 class _FakeMilestone:
@@ -192,113 +190,3 @@ def test_milestone_lookup_failure_is_not_fatal(monkeypatch, capsys):
     monkeypatch.setattr(release_config, "github_client", _raise)
     assert real_milestone_due_dates("galaxyproject", "galaxy") == {}
     assert "Warning: could not read milestones" in capsys.readouterr().err
-
-
-def test_falls_back_to_release_notes_when_github_is_unavailable(tmp_path, config_dir, milestones):
-    milestones({})
-    for documented in ("26.0.rst", "25.1.rst", "24.2.rst"):
-        (config_dir / documented).write_text("")
-    config = load_release_config(tmp_path, Version("26.1"))
-    assert config.previous_version == Version("26.0")
-    assert config.next_version == Version("26.2")
-    assert config.release_date is None
-
-
-def test_partial_yaml_is_accepted(tmp_path, config_dir):
-    """Fields a command does not need must not be required."""
-    _write_config(config_dir, "99.0_release.yml", "current-version: '99.0'\n")
-    config = load_release_config(tmp_path, Version("99.0"), use_github=False)
-    assert config.release_date is None
-    assert config.freeze_date is None
-
-
-def test_require_reports_missing_values(tmp_path, config_dir):
-    _write_config(config_dir, "99.0_release.yml", "current-version: '99.0'\n")
-    config = load_release_config(tmp_path, Version("99.0"), use_github=False)
-    with pytest.raises(ValueError, match=r"--release-date, --freeze-date"):
-        config.require("release_date", "freeze_date")
-
-
-def test_require_passes_when_values_are_known():
-    config = ReleaseConfig(current_version=Version("99.0"), release_date=datetime.date(2099, 1, 1))
-    config.require("release_date")
-
-
-def test_load_release_config_next_version_from_yaml(tmp_path, config_dir):
-    _write_config(config_dir, "98.2_release.yml", FULL_CONFIG + "next-version: '99.0'\n")
-    config = load_release_config(tmp_path, Version("98.2"), use_github=False)
-    assert config.next_version == Version("99.0")
-
-
-def test_load_release_config_null_field(tmp_path, config_dir):
-    _write_config(config_dir, "99.0_release.yml", "current-version: '99.0'\nprevious-version:\n")
-    with pytest.raises(ValueError, match="has no value"):
-        load_release_config(tmp_path, Version("99.0"), use_github=False)
-
-
-def test_load_release_config_invalid_version(tmp_path, config_dir):
-    _write_config(config_dir, "99.0_release.yml", "current-version: '!!!'\n")
-    with pytest.raises(ValueError, match="Invalid 'current-version'"):
-        load_release_config(tmp_path, Version("99.0"), use_github=False)
-
-
-def test_load_release_config_invalid_date(tmp_path, config_dir):
-    _write_config(config_dir, "99.0_release.yml", "current-version: '99.0'\nrelease-date: 'not-a-date'\n")
-    with pytest.raises(ValueError, match="Invalid 'release-date'"):
-        load_release_config(tmp_path, Version("99.0"), use_github=False)
-
-
-def test_load_release_config_not_a_mapping(tmp_path, config_dir):
-    _write_config(config_dir, "99.0_release.yml", "- item1\n- item2\n")
-    with pytest.raises(ValueError, match="must be a YAML mapping"):
-        load_release_config(tmp_path, Version("99.0"), use_github=False)
-
-
-def test_load_release_config_empty_yaml(tmp_path, config_dir, milestones):
-    _write_config(config_dir, "26.1_release.yml", "")
-    milestones({Version("26.1"): datetime.date(2026, 5, 20)})
-    config = load_release_config(tmp_path, Version("26.1"))
-    assert config.release_date == datetime.date(2026, 5, 20)
-
-
-def test_load_release_config_version_mismatch(tmp_path, config_dir):
-    path = _write_config(config_dir, "99.0_release.yml", "current-version: '98.0'\n")
-    with pytest.raises(ValueError, match="does not match release-version argument"):
-        load_release_config(tmp_path, Version("99.0"), release_config_path=path, use_github=False)
-
-
-def test_load_release_config_from_fixture():
-    config_path = Path("tests/test_data/release_98.2.yml")
-    config = load_release_config(Path("."), Version("98.2"), release_config_path=config_path, use_github=False)
-    assert config.current_version == Version("98.2")
-    assert config.previous_version == Version("98.1")
-    assert config.freeze_date == datetime.date(2099, 1, 1)
-    assert config.release_date == datetime.date(2099, 1, 15)
-
-
-def test_load_repo_owner_from_config(config_dir, tmp_path):
-    (config_dir / "98.2_release.yml").write_text(FULL_CONFIG + "owner: 'myorg'\nrepo: 'mygalaxy'\n")
-    owner, repo = load_repo_owner(tmp_path, Version("98.2"))
-    assert owner == "myorg"
-    assert repo == "mygalaxy"
-
-
-def test_load_repo_owner_point_release(config_dir, tmp_path):
-    """Point release version 98.2.1 should find config for 98.2."""
-    (config_dir / "98.2_release.yml").write_text(FULL_CONFIG + "owner: 'myorg'\nrepo: 'mygalaxy'\n")
-    owner, repo = load_repo_owner(tmp_path, Version("98.2.1"))
-    assert owner == "myorg"
-    assert repo == "mygalaxy"
-
-
-def test_load_repo_owner_defaults_when_no_config(tmp_path):
-    owner, repo = load_repo_owner(tmp_path, Version("99.0"))
-    assert owner == "galaxyproject"
-    assert repo == "galaxy"
-
-
-def test_load_repo_owner_defaults_when_no_owner_in_config(config_dir, tmp_path):
-    (config_dir / "98.2_release.yml").write_text(FULL_CONFIG)
-    owner, repo = load_repo_owner(tmp_path, Version("98.2"))
-    assert owner == "galaxyproject"
-    assert repo == "galaxy"

--- a/tests/test_release_config.py
+++ b/tests/test_release_config.py
@@ -4,7 +4,22 @@ from pathlib import Path
 import pytest
 from packaging.version import Version
 
-from galaxy_release_util.release_config import load_release_config, load_repo_owner
+from galaxy_release_util import release_config
+from galaxy_release_util.release_config import (
+    ReleaseConfig,
+    load_release_config,
+    load_repo_owner,
+)
+
+# Captured before the autouse stub below replaces it.
+real_milestone_due_dates = release_config.milestone_due_dates
+
+FULL_CONFIG = (
+    "current-version: '98.2'\n"
+    "previous-version: '98.1'\n"
+    "freeze-date: '2099-01-01'\n"
+    "release-date: '2099-01-15'\n"
+)
 
 
 @pytest.fixture
@@ -14,6 +29,26 @@ def config_dir(tmp_path):
     return releases_dir
 
 
+@pytest.fixture(autouse=True)
+def no_github(monkeypatch):
+    """Fail loudly if a test reaches for GitHub without saying so."""
+
+    def _explode(owner, repo):
+        raise AssertionError("test unexpectedly queried GitHub milestones")
+
+    monkeypatch.setattr(release_config, "milestone_due_dates", _explode)
+
+
+@pytest.fixture
+def milestones(monkeypatch):
+    """Stub the GitHub milestone lookup with a fixed {version: due date} mapping."""
+
+    def _set(due_dates):
+        monkeypatch.setattr(release_config, "milestone_due_dates", lambda owner, repo: due_dates)
+
+    return _set
+
+
 def _write_config(config_dir, filename, content):
     path = config_dir / filename
     path.write_text(content)
@@ -21,15 +56,10 @@ def _write_config(config_dir, filename, content):
 
 
 def test_load_release_config_default_path(tmp_path, config_dir):
-    _write_config(
-        config_dir,
-        "release_98.2.yml",
-        "current-version: '98.2'\nprevious-version: '98.1'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
-    )
-    config = load_release_config(tmp_path, Version("98.2"))
+    _write_config(config_dir, "98.2_release.yml", FULL_CONFIG)
+    config = load_release_config(tmp_path, Version("98.2"), use_github=False)
     assert config.current_version == Version("98.2")
     assert config.previous_version == Version("98.1")
-    assert config.next_version is None
     assert config.release_date == datetime.date(2099, 1, 15)
     assert config.freeze_date == datetime.date(2099, 1, 1)
     assert config.owner == "galaxyproject"
@@ -40,12 +70,12 @@ def test_load_release_config_explicit_path(tmp_path, config_dir):
     path = _write_config(
         config_dir,
         "custom.yml",
-        "current-version: '25.0'\nprevious-version: '24.2'\nrelease-date: '2025-07-01'\nfreeze-date: '2025-06-01'\nowner: myorg\nrepo: myrepo\n",
+        "current-version: '25.0'\nprevious-version: '24.2'\nrelease-date: '2025-07-01'\n"
+        "freeze-date: '2025-06-01'\nowner: myorg\nrepo: myrepo\n",
     )
-    config = load_release_config(tmp_path, Version("25.0"), release_config_path=path)
+    config = load_release_config(tmp_path, Version("25.0"), release_config_path=path, use_github=False)
     assert config.current_version == Version("25.0")
     assert config.previous_version == Version("24.2")
-    assert config.next_version is None
     assert config.release_date == datetime.date(2025, 7, 1)
     assert config.freeze_date == datetime.date(2025, 6, 1)
     assert config.owner == "myorg"
@@ -54,44 +84,17 @@ def test_load_release_config_explicit_path(tmp_path, config_dir):
 
 def test_load_release_config_explicit_path_missing(tmp_path):
     with pytest.raises(FileNotFoundError):
-        load_release_config(
-            tmp_path, Version("99.0"), release_config_path=tmp_path / "nonexistent.yml"
-        )
-
-
-def test_load_release_config_no_yaml_no_flags(tmp_path):
-    with pytest.raises(ValueError, match="missing required flag"):
-        load_release_config(tmp_path, Version("99.0"))
-
-
-def test_load_release_config_cli_only(tmp_path):
-    config = load_release_config(
-        tmp_path,
-        Version("99.0"),
-        previous_version=Version("98.0"),
-        release_date=datetime.date(2099, 1, 15),
-        freeze_date=datetime.date(2099, 1, 1),
-    )
-    assert config.current_version == Version("99.0")
-    assert config.previous_version == Version("98.0")
-    assert config.next_version is None
-    assert config.release_date == datetime.date(2099, 1, 15)
-    assert config.freeze_date == datetime.date(2099, 1, 1)
-    assert config.owner == "galaxyproject"
-    assert config.repo == "galaxy"
-
+        load_release_config(tmp_path, Version("99.0"), release_config_path=tmp_path / "nonexistent.yml")
 
 
 def test_load_release_config_cli_overrides_yaml(tmp_path, config_dir):
-    _write_config(
-        config_dir,
-        "release_98.2.yml",
-        "current-version: '98.2'\nprevious-version: '98.1'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
-    )
+    _write_config(config_dir, "98.2_release.yml", FULL_CONFIG)
     config = load_release_config(
-        tmp_path, Version("98.2"),
+        tmp_path,
+        Version("98.2"),
         next_version=Version("99.5"),
         release_date=datetime.date(2099, 6, 1),
+        use_github=False,
     )
     assert config.next_version == Version("99.5")
     assert config.release_date == datetime.date(2099, 6, 1)
@@ -99,107 +102,182 @@ def test_load_release_config_cli_overrides_yaml(tmp_path, config_dir):
     assert config.previous_version == Version("98.1")
 
 
-def test_load_release_config_missing_field(tmp_path, config_dir):
-    _write_config(
-        config_dir,
-        "release_99.0.yml",
-        "current-version: '99.0'\n",
+def test_load_release_config_needs_no_yaml_or_flags(tmp_path, milestones):
+    """The common case: nothing configured locally, everything read off the milestones."""
+    milestones(
+        {
+            Version("26.0"): datetime.date(2026, 1, 27),
+            Version("26.1"): datetime.date(2026, 5, 20),
+            Version("26.2"): datetime.date(2026, 10, 14),
+        }
     )
-    with pytest.raises(ValueError, match="Missing required field"):
-        load_release_config(tmp_path, Version("99.0"))
+    config = load_release_config(tmp_path, Version("26.1"))
+    assert config.release_date == datetime.date(2026, 5, 20)
+    assert config.previous_version == Version("26.0")
+    assert config.next_version == Version("26.2")
 
 
-def test_load_release_config_next_version_from_yaml(tmp_path, config_dir):
-    """next-version is still parsed from YAML if present (backward compat)."""
-    _write_config(
-        config_dir,
-        "release_98.2.yml",
-        "current-version: '98.2'\nprevious-version: '98.1'\nnext-version: '99.0'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
+def test_cli_flags_win_over_milestones(tmp_path, milestones):
+    milestones({Version("26.1"): datetime.date(2026, 5, 20), Version("26.2"): datetime.date(2026, 10, 14)})
+    config = load_release_config(
+        tmp_path,
+        Version("26.1"),
+        release_date=datetime.date(2026, 6, 1),
+        next_version=Version("27.0"),
     )
+    assert config.release_date == datetime.date(2026, 6, 1)
+    assert config.next_version == Version("27.0")
+
+
+def test_yaml_wins_over_milestones(tmp_path, config_dir, milestones):
+    _write_config(config_dir, "98.2_release.yml", FULL_CONFIG)
+    milestones({Version("98.2"): datetime.date(2050, 1, 1)})
     config = load_release_config(tmp_path, Version("98.2"))
+    assert config.release_date == datetime.date(2099, 1, 15)
+
+
+def test_milestone_fills_gaps_left_by_yaml(tmp_path, config_dir, milestones):
+    """A YAML without a release date still gets one from the milestone."""
+    _write_config(config_dir, "98.2_release.yml", "previous-version: '98.1'\n")
+    milestones({Version("98.2"): datetime.date(2050, 1, 1), Version("99.0"): None})
+    config = load_release_config(tmp_path, Version("98.2"))
+    assert config.previous_version == Version("98.1")
+    assert config.release_date == datetime.date(2050, 1, 1)
     assert config.next_version == Version("99.0")
 
 
-def test_load_release_config_null_required_field(tmp_path, config_dir):
-    _write_config(
-        config_dir,
-        "release_99.0.yml",
-        "current-version: '99.0'\nprevious-version:\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
+def test_milestone_without_due_date_leaves_release_date_unknown(tmp_path, milestones):
+    milestones({Version("98.2"): None})
+    config = load_release_config(tmp_path, Version("98.2"))
+    assert config.release_date is None
+
+
+class _FakeMilestone:
+    def __init__(self, title, due_on):
+        self.title = title
+        self.due_on = due_on
+
+
+class _FakeRepo:
+    def __init__(self, milestones):
+        self._milestones = milestones
+
+    def get_milestones(self, state):
+        return self._milestones
+
+
+class _FakeGithub:
+    def __init__(self, repo):
+        self._repo = repo
+
+    def get_repo(self, name):
+        return self._repo
+
+
+def test_unparsable_milestone_titles_are_ignored(monkeypatch):
+    repo = _FakeRepo(
+        [
+            _FakeMilestone("Backlog", None),
+            _FakeMilestone("26.1", datetime.datetime(2026, 5, 20)),
+        ]
     )
+    monkeypatch.setattr(release_config, "github_client", lambda: _FakeGithub(repo))
+    assert real_milestone_due_dates("galaxyproject", "galaxy") == {Version("26.1"): datetime.date(2026, 5, 20)}
+
+
+def test_milestone_lookup_failure_is_not_fatal(monkeypatch, capsys):
+    def _raise():
+        raise RuntimeError("no GitHub auth configured")
+
+    monkeypatch.setattr(release_config, "github_client", _raise)
+    assert real_milestone_due_dates("galaxyproject", "galaxy") == {}
+    assert "Warning: could not read milestones" in capsys.readouterr().err
+
+
+def test_falls_back_to_release_notes_when_github_is_unavailable(tmp_path, config_dir, milestones):
+    milestones({})
+    for documented in ("26.0.rst", "25.1.rst", "24.2.rst"):
+        (config_dir / documented).write_text("")
+    config = load_release_config(tmp_path, Version("26.1"))
+    assert config.previous_version == Version("26.0")
+    assert config.next_version == Version("26.2")
+    assert config.release_date is None
+
+
+def test_partial_yaml_is_accepted(tmp_path, config_dir):
+    """Fields a command does not need must not be required."""
+    _write_config(config_dir, "99.0_release.yml", "current-version: '99.0'\n")
+    config = load_release_config(tmp_path, Version("99.0"), use_github=False)
+    assert config.release_date is None
+    assert config.freeze_date is None
+
+
+def test_require_reports_missing_values(tmp_path, config_dir):
+    _write_config(config_dir, "99.0_release.yml", "current-version: '99.0'\n")
+    config = load_release_config(tmp_path, Version("99.0"), use_github=False)
+    with pytest.raises(ValueError, match=r"--release-date, --freeze-date"):
+        config.require("release_date", "freeze_date")
+
+
+def test_require_passes_when_values_are_known():
+    config = ReleaseConfig(current_version=Version("99.0"), release_date=datetime.date(2099, 1, 1))
+    config.require("release_date")
+
+
+def test_load_release_config_next_version_from_yaml(tmp_path, config_dir):
+    _write_config(config_dir, "98.2_release.yml", FULL_CONFIG + "next-version: '99.0'\n")
+    config = load_release_config(tmp_path, Version("98.2"), use_github=False)
+    assert config.next_version == Version("99.0")
+
+
+def test_load_release_config_null_field(tmp_path, config_dir):
+    _write_config(config_dir, "99.0_release.yml", "current-version: '99.0'\nprevious-version:\n")
     with pytest.raises(ValueError, match="has no value"):
-        load_release_config(tmp_path, Version("99.0"))
+        load_release_config(tmp_path, Version("99.0"), use_github=False)
 
 
 def test_load_release_config_invalid_version(tmp_path, config_dir):
-    _write_config(
-        config_dir,
-        "release_99.0.yml",
-        "current-version: '!!!'\nprevious-version: '98.0'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
-    )
+    _write_config(config_dir, "99.0_release.yml", "current-version: '!!!'\n")
     with pytest.raises(ValueError, match="Invalid 'current-version'"):
-        load_release_config(tmp_path, Version("99.0"))
+        load_release_config(tmp_path, Version("99.0"), use_github=False)
 
 
 def test_load_release_config_invalid_date(tmp_path, config_dir):
-    _write_config(
-        config_dir,
-        "release_99.0.yml",
-        "current-version: '99.0'\nprevious-version: '98.0'\nfreeze-date: '2099-01-01'\nrelease-date: 'not-a-date'\n",
-    )
+    _write_config(config_dir, "99.0_release.yml", "current-version: '99.0'\nrelease-date: 'not-a-date'\n")
     with pytest.raises(ValueError, match="Invalid 'release-date'"):
-        load_release_config(tmp_path, Version("99.0"))
-
-
-def test_load_release_config_null_freeze_date(tmp_path, config_dir):
-    _write_config(
-        config_dir,
-        "release_99.0.yml",
-        "current-version: '99.0'\nprevious-version: '98.0'\nrelease-date: '2099-01-15'\nfreeze-date:\n",
-    )
-    with pytest.raises(ValueError, match="has no value"):
-        load_release_config(tmp_path, Version("99.0"))
+        load_release_config(tmp_path, Version("99.0"), use_github=False)
 
 
 def test_load_release_config_not_a_mapping(tmp_path, config_dir):
-    _write_config(
-        config_dir,
-        "release_99.0.yml",
-        "- item1\n- item2\n",
-    )
+    _write_config(config_dir, "99.0_release.yml", "- item1\n- item2\n")
     with pytest.raises(ValueError, match="must be a YAML mapping"):
-        load_release_config(tmp_path, Version("99.0"))
+        load_release_config(tmp_path, Version("99.0"), use_github=False)
+
+
+def test_load_release_config_empty_yaml(tmp_path, config_dir, milestones):
+    _write_config(config_dir, "26.1_release.yml", "")
+    milestones({Version("26.1"): datetime.date(2026, 5, 20)})
+    config = load_release_config(tmp_path, Version("26.1"))
+    assert config.release_date == datetime.date(2026, 5, 20)
 
 
 def test_load_release_config_version_mismatch(tmp_path, config_dir):
-    _write_config(
-        config_dir,
-        "release_99.0.yml",
-        "current-version: '98.0'\nprevious-version: '97.0'\nfreeze-date: '2099-01-01'\nrelease-date: '2099-01-15'\n",
-    )
+    path = _write_config(config_dir, "99.0_release.yml", "current-version: '98.0'\n")
     with pytest.raises(ValueError, match="does not match release-version argument"):
-        load_release_config(tmp_path, Version("99.0"), release_config_path=config_dir / "release_99.0.yml")
+        load_release_config(tmp_path, Version("99.0"), release_config_path=path, use_github=False)
 
 
 def test_load_release_config_from_fixture():
     config_path = Path("tests/test_data/release_98.2.yml")
-    config = load_release_config(Path("."), Version("98.2"), release_config_path=config_path)
+    config = load_release_config(Path("."), Version("98.2"), release_config_path=config_path, use_github=False)
     assert config.current_version == Version("98.2")
     assert config.previous_version == Version("98.1")
-    assert config.next_version is None
     assert config.freeze_date == datetime.date(2099, 1, 1)
     assert config.release_date == datetime.date(2099, 1, 15)
 
 
 def test_load_repo_owner_from_config(config_dir, tmp_path):
-    config_content = (
-        "current-version: '98.2'\n"
-        "previous-version: '98.1'\n"
-        "release-date: '2099-01-15'\n"
-        "freeze-date: '2099-01-01'\n"
-        "owner: 'myorg'\n"
-        "repo: 'mygalaxy'\n"
-    )
-    (config_dir / "release_98.2.yml").write_text(config_content)
+    (config_dir / "98.2_release.yml").write_text(FULL_CONFIG + "owner: 'myorg'\nrepo: 'mygalaxy'\n")
     owner, repo = load_repo_owner(tmp_path, Version("98.2"))
     assert owner == "myorg"
     assert repo == "mygalaxy"
@@ -207,15 +285,7 @@ def test_load_repo_owner_from_config(config_dir, tmp_path):
 
 def test_load_repo_owner_point_release(config_dir, tmp_path):
     """Point release version 98.2.1 should find config for 98.2."""
-    config_content = (
-        "current-version: '98.2'\n"
-        "previous-version: '98.1'\n"
-        "release-date: '2099-01-15'\n"
-        "freeze-date: '2099-01-01'\n"
-        "owner: 'myorg'\n"
-        "repo: 'mygalaxy'\n"
-    )
-    (config_dir / "release_98.2.yml").write_text(config_content)
+    (config_dir / "98.2_release.yml").write_text(FULL_CONFIG + "owner: 'myorg'\nrepo: 'mygalaxy'\n")
     owner, repo = load_repo_owner(tmp_path, Version("98.2.1"))
     assert owner == "myorg"
     assert repo == "mygalaxy"
@@ -228,13 +298,7 @@ def test_load_repo_owner_defaults_when_no_config(tmp_path):
 
 
 def test_load_repo_owner_defaults_when_no_owner_in_config(config_dir, tmp_path):
-    config_content = (
-        "current-version: '98.2'\n"
-        "previous-version: '98.1'\n"
-        "release-date: '2099-01-15'\n"
-        "freeze-date: '2099-01-01'\n"
-    )
-    (config_dir / "release_98.2.yml").write_text(config_content)
+    (config_dir / "98.2_release.yml").write_text(FULL_CONFIG)
     owner, repo = load_repo_owner(tmp_path, Version("98.2"))
     assert owner == "galaxyproject"
     assert repo == "galaxy"


### PR DESCRIPTION
Creating or updating the changelog should not require passing release metadata by hand. It currently does:

```
$ galaxy-release-util create-changelog 26.1 --galaxy-root . --next-version 26.2
ValueError: No release config YAML found and missing required flag(s): --previous-version,
--release-date, --freeze-date. Provide a config YAML via --release-config or supply the flags directly.
```

#44 routed every command through `load_release_config`, which hard-requires `--previous-version`, `--release-date` and `--freeze-date` whenever no config YAML exists — and no such YAML exists in the Galaxy repo. `create-changelog` then throws two of those three away: it never reads `previous_version` or `freeze_date`.

That is how the bug arose. The YAML's required-field list, not the code, decided what each command demanded, and it had drifted from what the commands actually read.

## GitHub milestones are the source of truth

Flags win; anything left over comes from the milestones:

| value | resolved from |
| --- | --- |
| `release_date` | due date of the milestone titled `26.1` |
| `previous_version` | newest milestone before it (`26.0`) |
| `next_version` | oldest milestone after it (`26.2`) |

Milestone titles that aren't versions are skipped. A GitHub failure warns instead of aborting and falls back to release-note filenames for `previous_version`.

This also means the tooling tracks the milestone: 26.1's due date moved from 2026-05-20 to 2026-07-30 while this PR was being written, and `create-changelog` picked up the new date with no edit anywhere.

## Commands ask only for what they use

Every value is optional now; each command declares its own needs via `config.require(...)`:

| command | requires | resolved from |
| --- | --- | --- |
| `create-changelog` | release date, next version | milestones |
| `check-blocking-prs` | release date | milestones |
| `check-blocking-issues` | nothing but the repo name | — |
| `create-release-issue` | + freeze date | `--freeze-date` |

No milestone records a freeze date, so that stays a flag on `create-release-issue` — the one command that uses it. `--previous-version` and `--freeze-date` are dropped from the commands that ignored them, and the release-issue template loses the now-redundant flags.

## The config YAML is gone

Once the milestones supply the dates and versions, the YAML held nothing that a flag or a milestone did not already provide — except `owner`/`repo`, which become `--owner`/`--repo` (defaulting to `galaxyproject`/`galaxy`). `current-version` was only ever cross-checked against the `RELEASE_VERSION` argument, so it could only agree or error.

No `*_release.yml` has ever existed in the Galaxy repository, on any branch or in any commit, so nothing depends on this. Removing the last YAML reader also drops the `PyYAML` dependency.

**Breaking:** `--release-config` shipped in 0.3.3/0.3.4 and is removed. Nothing in the Galaxy repo or the release-issue template passes it.

## Verification

Against the real `galaxyproject/galaxy` milestones, `create-changelog 26.1` with no flags resolves the release date, `26.2` and `26.0`, runs to completion and collects all 532 PRs. Unresolvable values say what to do:

```
Error: Could not determine --release-date for release 26.1. Expected a milestone titled '26.1'
with a due date in galaxyproject/galaxy. Pass the value(s) explicitly.
```

## Note on the tests

The suite was red on `main` — 18 failures. #44's tests write `release_98.2.yml`, but the loader only ever looked for `98.2_release.yml`, so the config was never found and those assertions never exercised the loader they were testing. Both test modules are rewritten; 48 pass, with an autouse guard that fails any test reaching for GitHub.

`tests/test_build_command.py::test_build_integration` still fails. Pre-existing and unrelated — it clones Galaxy `dev`, whose package layout has moved. Left alone.

`flake8` is now clean repo-wide, and `mypy` is down to one pre-existing error in `point_release.py`. `ruff` has pre-existing errors on `main` that this PR does not take on.
