### PR TITLE
Read the package version from setup.cfg or pyproject.toml

### DIFF
--- a/galaxy_release_util/point_release.py
+++ b/galaxy_release_util/point_release.py
@@ -54,6 +54,31 @@ HISTORY_TEMPLATE = """History
 """
 RELEASE_BRANCH_REGEX = re.compile(r"^release_(\d{2}\.\d{1,2})$")
 FIRST_RELEASE_CHANGELOG_TEXT = "First release"
+# Older Galaxy branches declare the package version in ``setup.cfg``, newer ones in
+# ``pyproject.toml``. On branches that still use ``setup.cfg`` the ``pyproject.toml``
+# is a symlink to a shared build config that carries no version, so ``setup.cfg``
+# has to be consulted first.
+VERSION_FILENAMES = ("setup.cfg", "pyproject.toml")
+VERSION_LINE_REGEX = re.compile(r"""^version\s*=\s*(?P<quote>["']?)(?P<version>[^"'\s]+)(?P=quote)\s*$""")
+# Newer Galaxy releases moved the package sources under ``src``.
+PACKAGE_CODE_DIRS = (
+    Path("galaxy"),
+    Path("tests"),
+    Path("galaxy_test"),
+    Path("src", "galaxy"),
+    Path("src", "galaxy_test"),
+)
+
+
+def read_declared_version(version_file: Path) -> Optional[str]:
+    """Return the version declared in ``version_file``, or None if there is none."""
+    if not version_file.is_file():
+        return None
+    for line in version_file.read_text().splitlines():
+        match = VERSION_LINE_REGEX.match(line)
+        if match:
+            return match.group("version")
+    return None
 
 
 @dataclass
@@ -107,8 +132,13 @@ class Package:
         return self.path.name
 
     @property
-    def setup_cfg(self) -> Path:
-        return self.path / "setup.cfg"
+    def version_file(self) -> Path:
+        """The file that declares this package's version."""
+        for filename in VERSION_FILENAMES:
+            candidate = self.path / filename
+            if read_declared_version(candidate) is not None:
+                return candidate
+        raise ValueError(f"None of {', '.join(VERSION_FILENAMES)} in {self.path} contains a version line")
 
     @property
     def history_rst(self) -> Path:
@@ -136,7 +166,7 @@ class Package:
             # every commit is relevant:
             return [self.path / ".." / ".."]
         package_code_paths = []
-        for code_dir in ["galaxy", "tests", "galaxy_test"]:
+        for code_dir in PACKAGE_CODE_DIRS:
             package_code_path = self.path / code_dir
             if package_code_path.exists():
                 # get all symlinks pointing to a directory
@@ -204,16 +234,14 @@ def get_sorted_package_paths(galaxy_root: Path) -> List[Path]:
 
 
 def read_package(package_path: Path) -> Package:
-    setup_cfg = package_path / "setup.cfg"
-    package = None
-    with setup_cfg.open() as content:
-        for line in content:
-            if line.startswith("version = "):
-                version = line.strip().split("version = ")[-1]
-                package = Package(path=package_path, current_version=version)
-                break
-    if not package:
-        raise ValueError(f"{setup_cfg} does not contain version line")
+    version = None
+    for filename in VERSION_FILENAMES:
+        version = read_declared_version(package_path / filename)
+        if version is not None:
+            break
+    if version is None:
+        raise ValueError(f"None of {', '.join(VERSION_FILENAMES)} in {package_path} contains a version line")
+    package = Package(path=package_path, current_version=version)
     package.package_history = parse_changelog(package)
     return package
 
@@ -293,10 +321,19 @@ def parse_changelog(package: Package) -> List[ChangelogItem]:
 
 
 def bump_package_version(package: Package, new_version: Version) -> None:
-    content = package.setup_cfg.read_text().splitlines()
-    new_content = [f"version = {new_version}" if line.startswith("version = ") else line for line in content]
-    package.setup_cfg.write_text("\n".join(new_content) + "\n")
-    package.modified_paths.append(package.setup_cfg)
+    version_file = package.version_file
+    new_content = []
+    bumped = False
+    for line in version_file.read_text().splitlines():
+        match = VERSION_LINE_REGEX.match(line)
+        if match and not bumped:
+            # keep the quoting style of the file we're rewriting
+            quote = match.group("quote")
+            line = f"version = {quote}{new_version}{quote}"
+            bumped = True
+        new_content.append(line)
+    version_file.write_text("\n".join(new_content) + "\n")
+    package.modified_paths.append(version_file)
 
 
 def commits_to_prs(packages: List[Package], owner: str = PROJECT_OWNER, repo_name: str = PROJECT_NAME) -> None:
@@ -458,6 +495,30 @@ def get_branches(galaxy_root: Path, new_version: Version, current_branch: str) -
     return release_branches
 
 
+def restore_version_files(galaxy_root: Path, new_branch: str, package_path: Path) -> None:
+    """Restore a package's version metadata as it is on ``new_branch``.
+
+    Which file holds the version differs across branches: older ones use
+    ``setup.cfg``, newer ones ``pyproject.toml``. Merging an older branch forward
+    reintroduces ``setup.cfg`` as an unresolved delete/modify conflict, so any
+    version file the newer branch doesn't have is removed instead of restored.
+    """
+    for filename in VERSION_FILENAMES:
+        version_file = package_path / filename
+        exists_in_new_branch = (
+            subprocess.run(
+                ["git", "cat-file", "-e", f"{new_branch}:{version_file.relative_to(galaxy_root)}"],
+                cwd=galaxy_root,
+                capture_output=True,
+            ).returncode
+            == 0
+        )
+        if exists_in_new_branch:
+            subprocess.run(["git", "checkout", new_branch, str(version_file)], cwd=galaxy_root).check_returncode()
+        else:
+            subprocess.run(["git", "rm", "-f", "--ignore-unmatch", str(version_file)], cwd=galaxy_root)
+
+
 def merge_and_resolve_branches(
     galaxy_root: Path,
     base_branch: str,
@@ -532,10 +593,7 @@ def merge_and_resolve_branches(
         previous_package.package_history.insert(0, ChangelogItem(version=dev_version, changes=[], date=None))
         previous_package.write_history()
         subprocess.run(["git", "add", str(previous_package.history_rst)], cwd=galaxy_root)
-        # restore setup.cfg
-        subprocess.run(
-            ["git", "checkout", new_branch, str(previous_package.setup_cfg)], cwd=galaxy_root
-        ).check_returncode()
+        restore_version_files(galaxy_root, new_branch, previous_package.path)
     # Commit changes
     if merge_conflict:
         subprocess.run(["git", "commit", "--no-edit"], cwd=galaxy_root).check_returncode()

--- a/tests/test_point_release.py
+++ b/tests/test_point_release.py
@@ -6,6 +6,7 @@ from packaging.version import Version
 
 from galaxy_release_util.point_release import (
     Package,
+    bump_package_version,
     commits_to_prs,
     parse_changelog,
     read_package,
@@ -16,6 +17,25 @@ SETUP_CFG_CONTENTS = """\
 name = galaxy-app
 version = 23.0.2
 author = Galaxy Project
+"""
+
+# Shared build config that older branches symlink to as ``pyproject.toml``
+SHARED_PYPROJECT_CONTENTS = """\
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+"""
+
+# Newer branches declare the version in a per-package ``pyproject.toml``
+PYPROJECT_CONTENTS = """\
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "galaxy-app"
+version = "23.0.2"
+requires-python = ">=3.10"
 """
 
 HISTORY_RST_SIMPLE = """\
@@ -87,10 +107,18 @@ Not a real RST document
 """
 
 
-def _write_package(tmp_path: pathlib.Path, setup_cfg: str = SETUP_CFG_CONTENTS, history_rst: str = HISTORY_RST_SIMPLE):
+def _write_package(
+    tmp_path: pathlib.Path,
+    setup_cfg: str = SETUP_CFG_CONTENTS,
+    history_rst: str = HISTORY_RST_SIMPLE,
+    pyproject: str = SHARED_PYPROJECT_CONTENTS,
+):
     pkg_path = tmp_path / "galaxy-app"
     pkg_path.mkdir()
-    (pkg_path / "setup.cfg").write_text(setup_cfg)
+    if setup_cfg:
+        (pkg_path / "setup.cfg").write_text(setup_cfg)
+    if pyproject:
+        (pkg_path / "pyproject.toml").write_text(pyproject)
     (pkg_path / "HISTORY.rst").write_text(history_rst)
     return pkg_path
 
@@ -102,14 +130,54 @@ class TestReadPackage:
         assert package.current_version == "23.0.2"
         assert package.name == "galaxy-app"
         assert len(package.package_history) > 0
+        assert package.version_file == pkg_path / "setup.cfg"
+
+    def test_pyproject_only(self, tmp_path):
+        pkg_path = _write_package(tmp_path, setup_cfg="", pyproject=PYPROJECT_CONTENTS)
+        package = read_package(pkg_path)
+        assert package.current_version == "23.0.2"
+        assert package.version_file == pkg_path / "pyproject.toml"
+
+    def test_setup_cfg_wins_over_shared_pyproject(self, tmp_path):
+        # older branches symlink pyproject.toml to a shared, versionless build config
+        pkg_path = _write_package(tmp_path)
+        assert read_package(pkg_path).version_file == pkg_path / "setup.cfg"
 
     def test_missing_version(self, tmp_path):
         pkg_path = tmp_path / "broken"
         pkg_path.mkdir()
         (pkg_path / "setup.cfg").write_text("[metadata]\nname = broken\n")
         (pkg_path / "HISTORY.rst").write_text(HISTORY_RST_SIMPLE)
-        with pytest.raises(ValueError, match="does not contain version line"):
+        with pytest.raises(ValueError, match="contains a version line"):
             read_package(pkg_path)
+
+    def test_no_version_file(self, tmp_path):
+        pkg_path = tmp_path / "broken"
+        pkg_path.mkdir()
+        (pkg_path / "HISTORY.rst").write_text(HISTORY_RST_SIMPLE)
+        with pytest.raises(ValueError, match="contains a version line"):
+            read_package(pkg_path)
+
+
+class TestBumpPackageVersion:
+    def test_bumps_setup_cfg(self, tmp_path):
+        pkg_path = _write_package(tmp_path)
+        package = read_package(pkg_path)
+        bump_package_version(package, Version("23.0.3"))
+        assert "version = 23.0.3\n" in (pkg_path / "setup.cfg").read_text()
+        assert package.modified_paths == [pkg_path / "setup.cfg"]
+        # the shared build config is left alone
+        assert (pkg_path / "pyproject.toml").read_text() == SHARED_PYPROJECT_CONTENTS
+
+    def test_bumps_pyproject_keeping_quotes(self, tmp_path):
+        pkg_path = _write_package(tmp_path, setup_cfg="", pyproject=PYPROJECT_CONTENTS)
+        package = read_package(pkg_path)
+        bump_package_version(package, Version("23.0.3"))
+        contents = (pkg_path / "pyproject.toml").read_text()
+        assert 'version = "23.0.3"\n' in contents
+        # unrelated lines are preserved
+        assert 'name = "galaxy-app"' in contents
+        assert package.modified_paths == [pkg_path / "pyproject.toml"]
 
 
 class TestParseChangelog:


### PR DESCRIPTION
Galaxy's dev branch moved package metadata to PEP 621 pyproject.toml, so merging a release branch forward now dies in read_package on the first package of the dep DAG, which only ever looked at setup.cfg.

Which file carries the version cannot be decided by existence alone: branches that still use setup.cfg also have a pyproject.toml, but it is a symlink to a shared build config that declares no version. So setup.cfg is consulted first and only accepted when it actually declares one, and bump_package_version rewrites whichever file that turned out to be, preserving the quoting so pyproject.toml stays valid TOML.

Restoring the version file after a merge needs the same treatment, plus one more: merging a setup.cfg branch into a pyproject.toml branch leaves setup.cfg as an unresolved delete/modify conflict, so checking it out of the newer branch fails and the merge cannot be committed. restore_version_files follows what the root package.json already does -- ask git which file the newer branch has, restore that one, and drop the other.

code_paths gains the src layout dev also moved to. That failure is silent rather than loud: every package resolved zero source paths, so no commits were found and the changelog came out empty.