### PR TITLE
Resolve commits to pull requests in batched GraphQL queries

### DIFF
--- a/galaxy_release_util/metadata.py
+++ b/galaxy_release_util/metadata.py
@@ -1,11 +1,45 @@
 import re
-from typing import List
+from typing import (
+    List,
+    Protocol,
+    Sequence,
+)
 
 import click
-from github.PullRequest import PullRequest
 
 PROJECT_OWNER = "galaxyproject"
 PROJECT_NAME = "galaxy"
+
+
+class LabelLike(Protocol):
+    @property
+    def name(self) -> str:
+        raise NotImplementedError
+
+
+class PullRequestLike(Protocol):
+    """Subset of a pull request consumed here.
+
+    Satisfied both by ``github.PullRequest.PullRequest`` and by the summaries
+    that ``point_release`` builds from the GitHub GraphQL API.
+    """
+
+    @property
+    def number(self) -> int:
+        raise NotImplementedError
+
+    @property
+    def title(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def html_url(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def labels(self) -> Sequence[LabelLike]:
+        raise NotImplementedError
+
 
 GROUPED_TAGS = dict(
     [
@@ -24,7 +58,7 @@ def _pr_to_str(pr):
     return f"PR #{pr.number} ({pr.title}) {pr.html_url}"
 
 
-def _text_target(pull_request: PullRequest, skip_merge=True):
+def _text_target(pull_request: PullRequestLike, skip_merge=True):
     pr_number = pull_request.number
     labels = [label.name.lower() for label in pull_request.labels]
     is_bug = is_enhancement = is_feature = is_minor = is_major = is_merge = is_small_enhancement = False
@@ -89,7 +123,7 @@ def _text_target(pull_request: PullRequest, skip_merge=True):
     return text_target
 
 
-def _pr_to_labels(pr: PullRequest) -> List[str]:
+def _pr_to_labels(pr: PullRequestLike) -> List[str]:
     labels = [label.name.lower() for label in pr.labels]
     return labels
 

--- a/galaxy_release_util/point_release.py
+++ b/galaxy_release_util/point_release.py
@@ -2,15 +2,18 @@ import datetime
 import json
 import re
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import (
     dataclass,
     field,
 )
 from pathlib import Path
 from typing import (
+    Any,
     Dict,
     List,
     Optional,
+    Sequence,
     Set,
     Tuple,
 )
@@ -22,7 +25,7 @@ from docutils import (
     utils,
 )
 from docutils.parsers.rst import Parser
-from github import PullRequest
+from github import Github
 from packaging.version import Version
 
 from .cli.options import (
@@ -68,6 +71,50 @@ PACKAGE_CODE_DIRS = (
     Path("src", "galaxy"),
     Path("src", "galaxy_test"),
 )
+# A release can span thousands of commits, so commit -> PR lookups go through the
+# GraphQL API, which resolves a whole batch of commits per request.
+COMMITS_PER_GRAPHQL_QUERY = 100
+GRAPHQL_QUERY_WORKERS = 4
+COMMIT_PULL_REQUESTS_FRAGMENT = """
+fragment commitPullRequests on Commit {
+  associatedPullRequests(first: 10) {
+    nodes {
+      number
+      title
+      url
+      author {
+        login
+      }
+      labels(first: 50) {
+        nodes {
+          name
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@dataclass(frozen=True)
+class Label:
+    name: str
+
+
+@dataclass(frozen=True)
+class User:
+    login: str
+
+
+@dataclass(frozen=True)
+class PullRequestSummary:
+    """The pull request attributes needed to write a changelog entry."""
+
+    number: int
+    title: str
+    html_url: str
+    user: User
+    labels: Tuple[Label, ...]
 
 
 def read_declared_version(version_file: Path) -> Optional[str]:
@@ -122,7 +169,7 @@ class Package:
     path: Path
     current_version: str
     commits: Set[str] = field(default_factory=set)
-    prs: Set[PullRequest.PullRequest] = field(default_factory=set)
+    prs: Set[PullRequestSummary] = field(default_factory=set)
     modified_paths: List[Path] = field(default_factory=list)
     package_history: List[ChangelogItem] = field(default_factory=list)
     release_items: List[ReleaseItem] = field(default_factory=list)
@@ -336,26 +383,64 @@ def bump_package_version(package: Package, new_version: Version) -> None:
     package.modified_paths.append(version_file)
 
 
+def _build_commit_prs_query(batch_size: int) -> str:
+    """Build a query that resolves ``batch_size`` commits in a single request.
+
+    GraphQL cannot look up a list of commits, so each commit gets its own aliased
+    ``object`` selection.
+    """
+    variable_definitions = ", ".join(f"$commit{i}: String!" for i in range(batch_size))
+    selections = "\n    ".join(
+        f"commit{i}: object(expression: $commit{i}) {{ ...commitPullRequests }}" for i in range(batch_size)
+    )
+    return f"""query($owner: String!, $name: String!, {variable_definitions}) {{
+  repository(owner: $owner, name: $name) {{
+    {selections}
+  }}
+}}
+{COMMIT_PULL_REQUESTS_FRAGMENT}"""
+
+
+def _parse_pull_request(node: Dict[str, Any]) -> PullRequestSummary:
+    # The author is null for pull requests opened by since-deleted accounts.
+    author = node.get("author") or {}
+    return PullRequestSummary(
+        number=node["number"],
+        title=node["title"],
+        html_url=node["url"],
+        user=User(login=author.get("login", "ghost")),
+        labels=tuple(Label(name=label["name"]) for label in node["labels"]["nodes"]),
+    )
+
+
+def _fetch_commit_prs(
+    github: Github, owner: str, repo_name: str, commits: Sequence[str]
+) -> Dict[str, PullRequestSummary]:
+    """Map each commit of a single batch to its associated pull request, if any."""
+    variables: Dict[str, Any] = {"owner": owner, "name": repo_name}
+    variables.update({f"commit{i}": commit for i, commit in enumerate(commits)})
+    _, response = github.requester.graphql_query(_build_commit_prs_query(len(commits)), variables)
+    repository = response["data"]["repository"]
+    commit_to_pr = {}
+    for i, commit in enumerate(commits):
+        pull_requests = ((repository.get(f"commit{i}") or {}).get("associatedPullRequests") or {}).get("nodes") or []
+        for pull_request in pull_requests:
+            commit_to_pr[commit] = _parse_pull_request(pull_request)
+    return commit_to_pr
+
+
 def commits_to_prs(packages: List[Package], owner: str = PROJECT_OWNER, repo_name: str = PROJECT_NAME) -> None:
     g = github_client()
-    commits = set.union(*(p.commits for p in packages))
-    pr_cache = {}
-    commit_to_pr = {}
-    repo = g.get_repo(get_repo_name(owner, repo_name))
-    total_commits = len(commits)
-    skipped = []
-    for i, commit in enumerate(commits):
-        click.echo(f"Processing commit {i + 1} of {total_commits}")
-        # Get the list of pull requests associated with the commit
-        commit_obj = repo.get_commit(commit)
-        prs = commit_obj.get_pulls()
-        if not prs or prs.totalCount == 0:
-            skipped.append(commit)
-            continue
-        for pr in prs:
-            if pr.number not in pr_cache:
-                pr_cache[pr.number] = pr
-            commit_to_pr[commit] = pr_cache[pr.number]
+    commits = sorted(set.union(*(p.commits for p in packages)))
+    batches = [commits[i : i + COMMITS_PER_GRAPHQL_QUERY] for i in range(0, len(commits), COMMITS_PER_GRAPHQL_QUERY)]
+    click.echo(f"Finding pull requests for {len(commits)} commits in {len(batches)} queries")
+    commit_to_pr: Dict[str, PullRequestSummary] = {}
+    with ThreadPoolExecutor(max_workers=GRAPHQL_QUERY_WORKERS) as executor:
+        results = executor.map(lambda batch: _fetch_commit_prs(g, owner, repo_name, batch), batches)
+        for i, batch_result in enumerate(results):
+            commit_to_pr.update(batch_result)
+            click.echo(f"Processed query {i + 1} of {len(batches)}")
+    skipped = [commit for commit in commits if commit not in commit_to_pr]
     if skipped:
         click.echo(f"Warning: {len(skipped)} commit(s) have no associated PRs (e.g. merge commits):", err=True)
         for sha in skipped:

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     python-dateutil
     docutils
     packaging
-    PyGithub
+    PyGithub>=2.6
     requests
     twine
 packages = find:

--- a/tests/test_point_release.py
+++ b/tests/test_point_release.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from packaging.version import Version
 
+from galaxy_release_util import point_release
+from galaxy_release_util.metadata import _text_target
 from galaxy_release_util.point_release import (
     Package,
     bump_package_version,
@@ -218,54 +220,120 @@ class TestParseChangelog:
             parse_changelog(package)
 
 
+def _pr_node(number, labels=("kind/bug",), login="someuser"):
+    return {
+        "number": number,
+        "title": f"Fix thing {number}",
+        "url": f"https://github.com/galaxyproject/galaxy/pull/{number}",
+        "author": {"login": login},
+        "labels": {"nodes": [{"name": label} for label in labels]},
+    }
+
+
+class FakeRequester:
+    """Answers the batched commit -> PR query from a commit/PR-node mapping."""
+
+    def __init__(self, commit_to_pr_node):
+        self.commit_to_pr_node = commit_to_pr_node
+        self.queries = []
+
+    def graphql_query(self, query, variables):
+        self.queries.append(variables)
+        commits = [value for key, value in variables.items() if key.startswith("commit")]
+        repository = {}
+        for i, commit in enumerate(commits):
+            node = self.commit_to_pr_node.get(commit)
+            repository[f"commit{i}"] = {"associatedPullRequests": {"nodes": [node] if node else []}}
+        return {}, {"data": {"repository": repository}}
+
+
+def _patch_github(commit_to_pr_node):
+    requester = FakeRequester(commit_to_pr_node)
+    mock_github = MagicMock()
+    mock_github.requester = requester
+    return requester, patch("galaxy_release_util.point_release.github_client", return_value=mock_github)
+
+
 class TestCommitsToPrs:
     def test_commits_mapped_to_prs(self):
-        mock_pr = MagicMock()
-        mock_pr.number = 42
-        mock_pr.title = "Fix something"
-
-        mock_pulls = MagicMock()
-        mock_pulls.totalCount = 1
-        mock_pulls.__iter__ = MagicMock(return_value=iter([mock_pr]))
-        mock_pulls.__bool__ = MagicMock(return_value=True)
-
-        mock_commit = MagicMock()
-        mock_commit.get_pulls.return_value = mock_pulls
-
-        mock_repo = MagicMock()
-        mock_repo.get_commit.return_value = mock_commit
-
-        mock_github = MagicMock()
-        mock_github.get_repo.return_value = mock_repo
-
+        _, patched = _patch_github({"abc123": _pr_node(42)})
         package = Package(path=pathlib.Path("/fake"), current_version="1.0")
         package.commits = {"abc123"}
 
-        with patch("galaxy_release_util.point_release.github_client", return_value=mock_github):
+        with patched:
             commits_to_prs([package])
 
         assert len(package.prs) == 1
         pr = next(iter(package.prs))
         assert pr.number == 42
+        assert pr.title == "Fix thing 42"
+        assert pr.html_url == "https://github.com/galaxyproject/galaxy/pull/42"
+        assert pr.user.login == "someuser"
+        assert [label.name for label in pr.labels] == ["kind/bug"]
 
     def test_commits_without_prs_skipped(self):
-        mock_pulls = MagicMock()
-        mock_pulls.totalCount = 0
-        mock_pulls.__bool__ = MagicMock(return_value=False)
-
-        mock_commit = MagicMock()
-        mock_commit.get_pulls.return_value = mock_pulls
-
-        mock_repo = MagicMock()
-        mock_repo.get_commit.return_value = mock_commit
-
-        mock_github = MagicMock()
-        mock_github.get_repo.return_value = mock_repo
-
+        _, patched = _patch_github({})
         package = Package(path=pathlib.Path("/fake"), current_version="1.0")
         package.commits = {"abc123", "def456"}
 
-        with patch("galaxy_release_util.point_release.github_client", return_value=mock_github):
+        with patched:
             commits_to_prs([package])
 
         assert len(package.prs) == 0
+
+    def test_same_pr_across_commits_deduped(self):
+        node = _pr_node(42)
+        _, patched = _patch_github({"abc123": node, "def456": node})
+        package = Package(path=pathlib.Path("/fake"), current_version="1.0")
+        package.commits = {"abc123", "def456"}
+
+        with patched:
+            commits_to_prs([package])
+
+        assert len(package.prs) == 1
+
+    def test_commits_are_batched(self, monkeypatch):
+        monkeypatch.setattr(point_release, "COMMITS_PER_GRAPHQL_QUERY", 2)
+        commits = {f"commit{i}": _pr_node(i) for i in range(5)}
+        requester, patched = _patch_github(commits)
+        package = Package(path=pathlib.Path("/fake"), current_version="1.0")
+        package.commits = set(commits)
+
+        with patched:
+            commits_to_prs([package])
+
+        assert len(requester.queries) == 3
+        assert sorted(pr.number for pr in package.prs) == [0, 1, 2, 3, 4]
+
+    def test_prs_are_queried_for_the_requested_repo(self):
+        requester, patched = _patch_github({"abc123": _pr_node(42)})
+        package = Package(path=pathlib.Path("/fake"), current_version="1.0")
+        package.commits = {"abc123"}
+
+        with patched:
+            commits_to_prs([package], owner="someowner", repo_name="somerepo")
+
+        assert requester.queries[0]["owner"] == "someowner"
+        assert requester.queries[0]["name"] == "somerepo"
+
+    def test_missing_author_falls_back_to_ghost(self):
+        node = _pr_node(42)
+        node["author"] = None
+        _, patched = _patch_github({"abc123": node})
+        package = Package(path=pathlib.Path("/fake"), current_version="1.0")
+        package.commits = {"abc123"}
+
+        with patched:
+            commits_to_prs([package])
+
+        assert next(iter(package.prs)).user.login == "ghost"
+
+    def test_pr_summary_drives_changelog_categorization(self):
+        _, patched = _patch_github({"abc123": _pr_node(42, labels=("kind/enhancement", "area/tools"))})
+        package = Package(path=pathlib.Path("/fake"), current_version="1.0")
+        package.commits = {"abc123"}
+
+        with patched:
+            commits_to_prs([package])
+
+        assert _text_target(next(iter(package.prs)), skip_merge=False) == "enhancement_tag_tools\n"


### PR DESCRIPTION
## The problem

`commits_to_prs` resolves every commit in a release to its pull request with two or three REST calls — `get_commit`, `get_pulls`, and the `totalCount` lookup that paginates it.

Measured against `galaxyproject/galaxy`, that is **~1.3 s per commit**. A release spanning 2825 commits therefore spends close to an hour printing `Processing commit N of 2825`. Worse, 5650+ REST calls do not fit in the 5000 requests/hour rate limit, so a large release stalls once the limit is hit.

## The change

Resolve commits through the GraphQL API instead: 100 commits per request via aliased `object(expression:)` selections, four requests in flight.

| | before | after |
|---|---|---|
| 2825 commits | ~60 min | **33 s** |
| requests | 5650 REST | 29 GraphQL |
| rate limit | 5650 of 5000/hr (stalls) | 311 of 5000 points |

GraphQL returns plain dicts rather than PyGithub objects, so pull requests are now carried as a frozen `PullRequestSummary`, and `_text_target`/`_pr_to_labels` are typed against a `PullRequestLike` protocol that both it and PyGithub's `PullRequest` satisfy — `bootstrap_history` keeps passing real PyGithub objects unchanged.

`PyGithub>=2.6` is now required for `Github.requester.graphql_query`.

## Verification

- **Output is unchanged.** Ran the old and new implementations over the same real commits and compared every field that reaches the changelog — `number`, `title`, `html_url`, `user.login`, `labels`, and the resulting `_text_target` section. All identical.
- **Full scale.** A real 2825-commit run completes in 32.8 s and finds 649 pull requests.
- Commits with no associated pull request (direct pushes, including the release commits themselves) are still collected and reported through the existing warning.
- `TestCommitsToPrs` is reworked against the new seam and extended to cover batching, per-repo targeting, dedup across commits, and a null author; suite is 60 passed with `test_build_integration` failing identically on unmodified `main` in this environment.
- flake8/ruff clean; mypy reports the same single pre-existing error as `main`; black flags only pre-existing code (`main` is already not black-clean under black 25.1.0).