### PR TITLE
Fix meta package dependencies after PEP 621 migration

### DIFF
--- a/galaxy_release_util/point_release.py
+++ b/galaxy_release_util/point_release.py
@@ -869,13 +869,88 @@ def build_meta_dependencies(meta_package: Package, packages: List[Package], new_
     # Skip tool shed, should not be required at runtime, and skip meta package itself
     meta_deps = [f"galaxy-{p.name}=={new_version}" for p in packages if p.name not in ("meta", "tool_shed")]
     for line in meta_package.pinned_requirements_txt.read_text().splitlines():
-        if not line.startswith(("--", "#")):
-            meta_deps.append(line)
+        requirement = line.strip()
+        if requirement and not requirement.startswith(("--", "#")):
+            meta_deps.append(requirement)
     meta_deps.sort()
     requirements_txt = meta_package.path.joinpath("requirements.txt")
     requirements_txt.write_text("\n".join(meta_deps))
     # Don't add requirements.txt to meta_package.modified_paths, since this is
     # in Galaxy's .gitignore
+
+    pyproject_toml = meta_package.path / "pyproject.toml"
+    if _write_pyproject_dependencies(pyproject_toml, meta_deps):
+        return
+
+    # During Galaxy's transition to PEP 621, pyproject.toml declared dependencies
+    # as dynamic and setuptools still read their value from setup.cfg. The src
+    # layout migration accidentally removed this hook from the meta package.
+    setup_cfg = meta_package.path / "setup.cfg"
+    if _ensure_setup_cfg_requirements_file(setup_cfg):
+        return
+
+    raise ValueError(
+        f"Cannot configure dependencies for meta package at {meta_package.path}: "
+        "expected [project].dependencies in pyproject.toml or [options] in setup.cfg"
+    )
+
+
+def _write_pyproject_dependencies(pyproject_toml: Path, dependencies: List[str]) -> bool:
+    """Replace a static PEP 621 dependency list, preserving the rest of the file."""
+    if not pyproject_toml.is_file():
+        return False
+
+    lines = pyproject_toml.read_text().splitlines(keepends=True)
+    try:
+        project_start = next(i for i, line in enumerate(lines) if line.strip() == "[project]") + 1
+    except StopIteration:
+        return False
+    project_end = next((i for i in range(project_start, len(lines)) if lines[i].lstrip().startswith("[")), len(lines))
+
+    dependency_start = None
+    dependency_end = None
+    assignment = re.compile(r"^\s*dependencies\s*=\s*\[")
+    closing_bracket = re.compile(r"^\s*\]\s*(?:#.*)?$")
+    for i in range(project_start, project_end):
+        match = assignment.match(lines[i])
+        if not match:
+            continue
+        dependency_start = i
+        if "]" in lines[i][match.end() :]:
+            dependency_end = i + 1
+        else:
+            dependency_end = next(
+                (j + 1 for j in range(i + 1, project_end) if closing_bracket.match(lines[j].rstrip("\n"))),
+                None,
+            )
+        break
+
+    if dependency_start is None or dependency_end is None:
+        return False
+
+    rendered = ["dependencies = [\n"]
+    rendered.extend(f"    {json.dumps(dependency)},\n" for dependency in dependencies)
+    rendered.append("]\n")
+    lines[dependency_start:dependency_end] = rendered
+    pyproject_toml.write_text("".join(lines))
+    return True
+
+
+def _ensure_setup_cfg_requirements_file(setup_cfg: Path) -> bool:
+    """Ensure legacy dynamic metadata reads the generated requirements file."""
+    if not setup_cfg.is_file():
+        return False
+
+    lines = setup_cfg.read_text().splitlines(keepends=True)
+    try:
+        options_start = next(i for i, line in enumerate(lines) if line.strip() == "[options]") + 1
+    except StopIteration:
+        return False
+    options_end = next((i for i in range(options_start, len(lines)) if lines[i].lstrip().startswith("[")), len(lines))
+    if not any(re.match(r"^\s*install_requires\s*=", lines[i]) for i in range(options_start, options_end)):
+        lines.insert(options_start, "install_requires = file: requirements.txt\n")
+        setup_cfg.write_text("".join(lines))
+    return True
 
 
 def show_modified_paths_and_diff(galaxy_root: Path, modified_paths: List[Path], no_confirm: bool) -> None:

--- a/tests/test_point_release.py
+++ b/tests/test_point_release.py
@@ -6,6 +6,7 @@ from packaging.version import Version
 
 from galaxy_release_util.point_release import (
     Package,
+    build_meta_dependencies,
     bump_package_version,
     commits_to_prs,
     parse_changelog,
@@ -178,6 +179,72 @@ class TestBumpPackageVersion:
         # unrelated lines are preserved
         assert 'name = "galaxy-app"' in contents
         assert package.modified_paths == [pkg_path / "pyproject.toml"]
+
+
+class TestBuildMetaDependencies:
+    def _packages(self, tmp_path):
+        meta_path = tmp_path / "packages" / "meta"
+        meta_path.mkdir(parents=True)
+        pinned_requirements = tmp_path / "lib" / "galaxy" / "dependencies" / "pinned-requirements.txt"
+        pinned_requirements.parent.mkdir(parents=True)
+        pinned_requirements.write_text("# generated\nrequests==2.32.4\n\n--extra-index-url https://example.com\n")
+        return meta_path, [
+            Package(path=tmp_path / "packages" / name, current_version="26.1.dev0")
+            for name in ("util", "tool_shed", "meta", "app")
+        ]
+
+    def test_writes_static_pyproject_dependencies(self, tmp_path):
+        meta_path, packages = self._packages(tmp_path)
+        pyproject = meta_path / "pyproject.toml"
+        pyproject.write_text("""\
+[project]
+name = "galaxy"
+dependencies = [
+]
+
+[project.optional-dependencies]
+postgresql = ["psycopg[binary]"]
+""")
+
+        build_meta_dependencies(packages[2], packages, Version("26.1"))
+
+        contents = pyproject.read_text()
+        assert '    "galaxy-app==26.1",\n' in contents
+        assert '    "galaxy-util==26.1",\n' in contents
+        assert '    "requests==2.32.4",\n' in contents
+        assert "galaxy-meta" not in contents
+        assert "galaxy-tool_shed" not in contents
+        assert 'postgresql = ["psycopg[binary]"]' in contents
+
+    def test_restores_legacy_setup_cfg_requirements_hook(self, tmp_path):
+        meta_path, packages = self._packages(tmp_path)
+        (meta_path / "pyproject.toml").write_text("""\
+[project]
+dynamic = ["dependencies", "version"]
+name = "galaxy"
+""")
+        setup_cfg = meta_path / "setup.cfg"
+        setup_cfg.write_text("""\
+[metadata]
+version = 26.1.dev0
+
+[options]
+packages = find:
+python_requires = >=3.10
+
+[options.extras_require]
+postgresql =
+    psycopg[binary]
+""")
+
+        build_meta_dependencies(packages[2], packages, Version("26.1"))
+
+        assert "[options]\ninstall_requires = file: requirements.txt\n" in setup_cfg.read_text()
+        assert (meta_path / "requirements.txt").read_text().splitlines() == [
+            "galaxy-app==26.1",
+            "galaxy-util==26.1",
+            "requests==2.32.4",
+        ]
 
 
 class TestParseChangelog:


### PR DESCRIPTION
## Summary

- write assembled meta-package dependencies into static PEP 621 `project.dependencies`
- restore the generated `requirements.txt` hook for the transitional Galaxy 26.1 `setup.cfg` layout
- ignore blank, comment, and pip option lines while assembling dependencies
- add regression coverage for both metadata layouts

## Root cause

`build_meta_dependencies` continued generating `packages/meta/requirements.txt`, but Galaxy commit `b7f83c84698` removed the `install_requires = file: requirements.txt` consumer from the transitional setup. The completed PEP 621 migration then declared an empty static dependency list, so neither layout consumed the generated dependencies.

## Testing

- `pytest -q tests/test_point_release.py`: 15 passed
- full unit suite: 57 passed; the upstream Galaxy build integration reaches the meta package and fails on the separate existing `egg_base` configuration (`packages/meta/src` does not exist)
- focused Flake8 and `git diff --check` pass